### PR TITLE
Feat/core/raytracer class implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.a
 *.so
+*.ppm
 
 /build
 /plugins

--- a/include/components/ICamera.hpp
+++ b/include/components/ICamera.hpp
@@ -12,6 +12,9 @@ public:
     virtual ~ICamera() = default;
 
     virtual Ray get_ray(double u, double v) const = 0;
+
+    virtual int getWidth() const = 0;
+    virtual int getHeight() const = 0;
 };
 
 } // namespace Raytracer

--- a/include/math/MathUtils.hpp
+++ b/include/math/MathUtils.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cmath>
+
+namespace Raytracer
+{
+
+class Math
+{
+public:
+    /**
+     * @brief Convert degrees to radians
+     */
+    static inline double degreesToRadians(double degrees) {
+        return degrees * M_PI / 180.0;
+    }
+
+    /**
+     * @brief Convert radians to degrees
+     */
+    static inline double radiansToDegrees(double radians) {
+        return radians * 180.0 / M_PI;
+    }
+};
+
+} // namespace Raytracer

--- a/include/render/FrameBuffer.hpp
+++ b/include/render/FrameBuffer.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <vector>
+#include "math/Color.hpp"
+
+namespace Raytracer
+{
+
+using FrameBuffer = std::vector<Color>;
+
+} // namespace Raytracer

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_library(raytracer_core STATIC
     Raytracer.cpp
     camera/PerspectiveCamera.cpp
+    renderer/Renderer.cpp
+    image/Image.cpp
+    ../primitives/sphere/Sphere.cpp
 )
 
 target_include_directories(raytracer_core PUBLIC

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -1,4 +1,7 @@
 #include "Raytracer.hpp"
+#include "core/camera/PerspectiveCamera.hpp"
+#include "primitives/sphere/Sphere.hpp"
+#include "core/image/Image.hpp"
 
 namespace Raytracer
 {
@@ -13,6 +16,15 @@ void Raytracer::run()
 {
     if (_exitCode != SUCCESS_STATUS)
         return;
+
+    FrameBuffer frameBuffer;
+    PerspectiveCamera camera(Vector3D::zero(), Vector3D::zero(), 75, 16.0/9.0, 1920, 1080);
+    Image _image(camera.getWidth(), camera.getHeight());
+
+    auto world = std::make_shared<Sphere>(Vector3D(0, 0, -1), 0.5);
+
+    _renderer.render(camera, *world, frameBuffer);
+    _image.drawFromBuffer(frameBuffer);
 }
 
 } // namespace Raytracer

--- a/src/core/Raytracer.hpp
+++ b/src/core/Raytracer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "math/Ray.hpp"
+#include "core/renderer/Renderer.hpp"
 
 namespace Raytracer
 {
@@ -20,6 +21,9 @@ private:
 
 private:
     int _exitCode = SUCCESS_STATUS;
+
+private:
+    Renderer _renderer;
 };
 
 } // namespace Raytracer

--- a/src/core/camera/ACamera.hpp
+++ b/src/core/camera/ACamera.hpp
@@ -8,22 +8,28 @@ namespace Raytracer
 
 class ACamera : public ICamera
 {
+public:
+    int getWidth() const override { return _width; }
+    int getHeight() const override { return _height; }
+
 protected:
     Point3D _origin;
     Vector3D _forward;
     Vector3D _right;
     Vector3D _up;
+    int _width;
+    int _height;
 
-    ACamera(const Point3D& origin, const Vector3D& rotation, const Vector3D& vup) 
-        : _origin(origin) 
+    ACamera(const Point3D& origin, const Vector3D& rotation, const Vector3D& vup, int width, int height) 
+        : _origin(origin), _width(width), _height(height)
     {
         double pitch = rotation.x * M_PI / 180.0;
         double yaw   = rotation.y * M_PI / 180.0;
 
         _forward = Vector3D(
-            std::cos(pitch) * std::sin(yaw),
-            std::sin(pitch),
-            std::cos(pitch) * std::cos(yaw)
+            cos(pitch) * sin(yaw),
+            sin(pitch),
+            -cos(pitch) * cos(yaw)
         ).normalized();
 
         _setupBase(vup);

--- a/src/core/camera/ACamera.hpp
+++ b/src/core/camera/ACamera.hpp
@@ -2,6 +2,7 @@
 
 #include "math/Vector3D.hpp"
 #include "components/ICamera.hpp"
+#include "math/MathUtils.hpp"
 
 namespace Raytracer
 {
@@ -23,8 +24,9 @@ protected:
     ACamera(const Point3D& origin, const Vector3D& rotation, const Vector3D& vup, int width, int height) 
         : _origin(origin), _width(width), _height(height)
     {
-        double pitch = rotation.x * M_PI / 180.0;
-        double yaw   = rotation.y * M_PI / 180.0;
+        double pitch = Math::degreesToRadians(rotation.x);
+        double yaw   = Math::degreesToRadians(rotation.y);
+        double roll  = Math::degreesToRadians(rotation.z);
 
         _forward = Vector3D(
             cos(pitch) * sin(yaw),
@@ -33,6 +35,14 @@ protected:
         ).normalized();
 
         _setupBase(vup);
+
+        if (roll != 0) {
+            Vector3D old_right = _right;
+            Vector3D old_up = _up;
+
+            _right = old_right * cos(roll) + old_up * sin(roll);
+            _up = old_up * cos(roll) - old_right * sin(roll);
+        }
     }
 
 private:

--- a/src/core/camera/PerspectiveCamera.cpp
+++ b/src/core/camera/PerspectiveCamera.cpp
@@ -5,8 +5,8 @@
 namespace Raytracer
 {
 
-PerspectiveCamera::PerspectiveCamera(const Point3D& origin, const Vector3D& rotation, double fov, double aspect_ratio)
-    : ACamera(origin, rotation, Vector3D::up())
+PerspectiveCamera::PerspectiveCamera(const Point3D& origin, const Vector3D& rotation, double fov, double aspect_ratio, int width, int height)
+    : ACamera(origin, rotation, Vector3D::up(), width, height)
 {
     _initialize(fov, aspect_ratio);
 }

--- a/src/core/camera/PerspectiveCamera.hpp
+++ b/src/core/camera/PerspectiveCamera.hpp
@@ -8,7 +8,7 @@ namespace Raytracer
 class PerspectiveCamera : public ACamera
 {
 public:
-    PerspectiveCamera(const Point3D& origin, const Vector3D& rotation, double fov, double aspect_ratio);
+    PerspectiveCamera(const Point3D& origin, const Vector3D& rotation, double fov, double aspect_ratio, int width, int height);
 
     Ray get_ray(double u, double v) const override;
 

--- a/src/core/image/Image.cpp
+++ b/src/core/image/Image.cpp
@@ -1,0 +1,20 @@
+#include "Image.hpp"
+
+namespace Raytracer
+{
+
+void Image::drawFromBuffer(const FrameBuffer& buffer, const std::string& filename)
+{
+    std::ofstream file(filename);
+    file << "P3\n" << _width << " " << _height << "\n255\n";
+
+    for (const auto& color : buffer) {
+        int ir = Color::to_byte(color.r);
+        int ig = Color::to_byte(color.g);
+        int ib = Color::to_byte(color.b);
+
+        file << ir << " " << ig << " " << ib << "\n";
+    }
+}
+
+} // namespace Raytracer

--- a/src/core/image/Image.hpp
+++ b/src/core/image/Image.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <fstream>
+#include <algorithm>
+#include "render/FrameBuffer.hpp"
+
+namespace Raytracer
+{
+
+class Image
+{
+public:
+    Image(int width, int height) : _width(width), _height(height) {}
+
+    void drawFromBuffer(const FrameBuffer& buffer, const std::string& filename = "output.ppm");
+
+private:
+    int _width;
+    int _height;
+};
+
+} // namespace Raytracer

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -10,12 +10,12 @@ void Renderer::render(const ICamera& camera, const IPrimitive& world, FrameBuffe
 
     buffer.assign(width * height, Color(0, 0, 0));
 
-    for (int y = height - 1; y >= 0; --y) {
+    for (int y = 0; y < height; ++y) {
         for (int x = 0; x < width; ++x) {
             Color pixel_color;
 
             double u = static_cast<double>(x) / (width - 1.0);
-            double v = static_cast<double>(y) / (height - 1.0);
+            double v = 1.0 - static_cast<double>(y) / (height - 1.0);
 
             Ray r = camera.get_ray(u, v);
             pixel_color += ray_color(r, world, 50);

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -1,0 +1,42 @@
+#include "Renderer.hpp"
+
+namespace Raytracer
+{
+
+void Renderer::render(const ICamera& camera, const IPrimitive& world, FrameBuffer& buffer)
+{
+    int width = camera.getWidth();
+    int height = camera.getHeight();
+
+    buffer.assign(width * height, Color(0, 0, 0));
+
+    for (int y = height - 1; y >= 0; --y) {
+        for (int x = 0; x < width; ++x) {
+            Color pixel_color;
+
+            double u = static_cast<double>(x) / (width - 1.0);
+            double v = static_cast<double>(y) / (height - 1.0);
+
+            Ray r = camera.get_ray(u, v);
+            pixel_color += ray_color(r, world, 50);
+            buffer[y * width + x] = pixel_color;
+        }
+    }
+}
+
+Color Renderer::ray_color(const Ray& r, const IPrimitive& world, int depth)
+{
+    if (depth <= 0)
+        return Color(0, 0, 0);
+
+    HitRecord rec;
+    if (world.hit(r, Interval(0.001, Interval::universe.max), rec)) {
+        return 0.5 * (Color(rec.normal.x, rec.normal.y, rec.normal.z) + Color(1, 1, 1));
+    }
+
+    Vector3D unit_direction = r.direction().normalized();
+    double t = 0.5 * (unit_direction.y + 1.0);
+    return (1.0 - t) * Color(1, 1, 1) + t * Color(0.5, 0.7, 1.0);
+}
+
+} // namespace Raytracer

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include "components/ICamera.hpp"
+#include "components/IPrimitive.hpp"
+#include "render/FrameBuffer.hpp"
+
+
+namespace Raytracer
+{
+
+class Renderer {
+public:
+    Renderer(int samples = 10, int depth = 50) 
+        : _samples(samples), _maxDepth(depth) {}
+    ~Renderer() = default;
+
+    void render(const ICamera& camera, const IPrimitive& world, FrameBuffer& buffer);
+
+private:
+    int _samples;
+    int _maxDepth;
+    Color ray_color(const Ray& r, const IPrimitive& world, int depth);
+};
+
+} // namespace Raytracer

--- a/src/primitives/sphere/Sphere.hpp
+++ b/src/primitives/sphere/Sphere.hpp
@@ -13,6 +13,8 @@ namespace Raytracer
 
             bool hit(const Ray& r, Interval ray_t, HitRecord& rec) const;
 
+            std::string getName() const override { return "Sphere"; }
+
         private:
             Point3D _center;
             double _radius;


### PR DESCRIPTION
## FIXES

Issue #24 
Issue #4 
Issue #3 
Issue #7 

## Description

This PR implements the core rendering pipeline for the raytracer and finalizes the branch work around camera, rendering, image output, and math utilities.

### How

- Added the `Raytracer` execution flow to build a simple scene, create the camera, run the renderer, and export the final image.
- Added `FrameBuffer` support to store rendered pixel colors.
- Implemented the `Renderer` class with `render()` and `ray_color()` to generate the image.
- Implemented `Image::drawFromBuffer()` to export the framebuffer to a PPM file.
- Updated camera orientation handling in `ACamera` and added `MathUtils` for degree/radian conversions.
- Extended interfaces/components needed by the rendering pipeline (`ICamera`, `Sphere`).
- Fixed vertical inversion on Y by aligning framebuffer row traversal with image writing order and flipping camera `v` sampling accordingly.

### Testing
1. **Execution**: `./raytracer`
2. **Validation**: Verified successful execution and checked that the generated image is no longer vertically flipped.

### Notes
- **Next**: None.
- **Technical Details**: The inversion bug came from a mismatch between render-loop Y traversal and camera vertical UV mapping.
- **Refactoring**: No extra refactor beyond required integration and orientation correction.