### PR TITLE
feat(light): implement PointLight class and integrate into rendering pipeline

### DIFF
--- a/include/components/ILight.hpp
+++ b/include/components/ILight.hpp
@@ -7,16 +7,18 @@
 namespace Raytracer
 {
 
-class ILight
-{
+struct LightSample {
+    Color color;
+    Vector3D direction;
+    double distance;
+    bool isActive;
+};
+
+class ILight {
 public:
     virtual ~ILight() = default;
-
-    virtual bool illuminate(
-        const HitRecord& rec,
-        Vector3D& light_dir,
-        Color& light_color
-    ) const = 0;
+    
+    virtual LightSample computeLight(const Point3D& hit_point) const = 0;
 };
 
 } // namespace Raytracer

--- a/include/math/Color.hpp
+++ b/include/math/Color.hpp
@@ -40,4 +40,6 @@ inline Color operator*(const Color& u, const Color& v) noexcept { return {u.r * 
 inline Color operator*(double t, const Color& v) noexcept { return {t * v.r, t * v.g, t * v.b}; }
 inline Color operator*(const Color& v, double t) noexcept { return t * v; }
 
+inline Color operator/(const Color& v, double t) noexcept { return (1.0 / t) * v; }
+
 } // namespace Raytracer

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -25,6 +25,14 @@ struct Vector3D
         return *this;
     }
 
+    inline constexpr void normalize() noexcept {
+        double l = length();
+        if (l > 0) {
+            double inv = 1.0 / l;
+            x *= inv; y *= inv; z *= inv;
+        }
+    }
+
     Vector3D& operator/=(double t) noexcept {
         return *this *= (1.0 / t);
     }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(raytracer_core STATIC
     image/Image.cpp
     ../primitives/sphere/Sphere.cpp
     ../materials/lambertian/Lambertian.cpp
+    ../lights/point_light/PointLight.cpp
 )
 
 target_include_directories(raytracer_core PUBLIC

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -3,6 +3,7 @@
 #include "primitives/sphere/Sphere.hpp"
 #include "core/image/Image.hpp"
 #include "materials/lambertian/Lambertian.hpp"
+#include "lights/point_light/PointLight.hpp"
 
 namespace Raytracer
 {
@@ -25,8 +26,11 @@ void Raytracer::run()
 
     auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, -3), 0.5, lambertian);
     auto sphere2 = std::make_shared<Sphere>(Vector3D(1.2, 0, -3), 0.5, lambertian);
+    auto light = std::make_shared<PointLight>(Vector3D(1, 1.4, -2), Color(1, 1, 1), .5);
     _scene.addPrimitive(sphere);
     _scene.addPrimitive(sphere2);
+    _scene.addLight(light);
+    _scene.setBackgroundColor(Color(0, 0, 0));
 
     _renderer.render(camera, _scene, frameBuffer);
     _image.drawFromBuffer(frameBuffer);

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -34,12 +34,32 @@ Color Renderer::ray_color(const Ray& r, const Scene& scene, int depth) {
         Color attenuation;
 
         if (rec.material->scatter(r, rec, attenuation, scattered)) {
-            return attenuation * ray_color(scattered, scene, depth - 1);
+            Color direct_light = compute_direct_lighting(rec, scene, attenuation);
+
+            return direct_light + attenuation * ray_color(scattered, scene, depth - 1);
         }
         return Color(0, 0, 0);
     }
 
     return scene.getBackground(r);
+}
+
+Color Renderer::compute_direct_lighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)
+{
+    Color direct_light(0, 0, 0);
+    for (const auto& light : scene.getLights()) {
+        LightSample sample = light->computeLight(rec.point);
+        if (!sample.isActive) continue;
+
+        Ray shadow_ray(rec.point + rec.normal * 0.001, sample.direction);
+        HitRecord shadow_rec;
+
+        if (!scene.getWorld().hit(shadow_ray, Interval(0.001, sample.distance), shadow_rec)) {
+            double cos_theta = std::max(0.0, rec.normal.dot(sample.direction));
+            direct_light += (attenuation * sample.color) * cos_theta;
+        }
+    }
+    return direct_light;
 }
 
 } // namespace Raytracer

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -19,13 +19,13 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
             double v = 1.0 - static_cast<double>(y) / (height - 1.0);
 
             Ray r = camera.get_ray(u, v);
-            pixel_color += ray_color(r, scene, 50);
+            pixel_color += computeRayColor(r, scene, 50);
             buffer[y * width + x] = pixel_color;
         }
     }
 }
 
-Color Renderer::ray_color(const Ray& r, const Scene& scene, int depth) {
+Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {
     if (depth <= 0) return Color(0, 0, 0);
 
     HitRecord rec;
@@ -34,9 +34,9 @@ Color Renderer::ray_color(const Ray& r, const Scene& scene, int depth) {
         Color attenuation;
 
         if (rec.material->scatter(r, rec, attenuation, scattered)) {
-            Color direct_light = compute_direct_lighting(rec, scene, attenuation);
+            Color direct_light = computeDirectLighting(rec, scene, attenuation);
 
-            return direct_light + attenuation * ray_color(scattered, scene, depth - 1);
+            return direct_light + attenuation * computeRayColor(scattered, scene, depth - 1);
         }
         return Color(0, 0, 0);
     }
@@ -44,7 +44,7 @@ Color Renderer::ray_color(const Ray& r, const Scene& scene, int depth) {
     return scene.getBackground(r);
 }
 
-Color Renderer::compute_direct_lighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)
+Color Renderer::computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)
 {
     Color direct_light(0, 0, 0);
     for (const auto& light : scene.getLights()) {

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -22,8 +22,8 @@ public:
 private:
     int _samples;
     int _maxDepth;
-    Color ray_color(const Ray& r, const Scene& scene, int depth);
-    Color compute_direct_lighting(const HitRecord& rec, const Scene& scene, const Color& attenuation);
+    Color computeRayColor(const Ray& r, const Scene& scene, int depth);
+    Color computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation);
 };
 
 } // namespace Raytracer

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -23,6 +23,7 @@ private:
     int _samples;
     int _maxDepth;
     Color ray_color(const Ray& r, const Scene& scene, int depth);
+    Color compute_direct_lighting(const HitRecord& rec, const Scene& scene, const Color& attenuation);
 };
 
 } // namespace Raytracer

--- a/src/core/scene/Scene.cpp
+++ b/src/core/scene/Scene.cpp
@@ -5,9 +5,10 @@ namespace Raytracer
 
 Color Scene::getBackground(const Ray& r) const
 {
-    Vector3D unit_dir = r.direction().normalized();
-    double t = 0.5 * (unit_dir.y + 1.0);
-    return (1.0 - t) * Color(1, 1, 1) + t * _backgroundColor;
+    // Vector3D unit_dir = r.direction().normalized();
+    // double t = 0.5 * (unit_dir.y + 1.0);
+    // return (1.0 - t) * Color(1, 1, 1) + t * _backgroundColor;
+    return _backgroundColor;
 }
 
 } // namespace Raytracer

--- a/src/lights/CMakeLists.txt
+++ b/src/lights/CMakeLists.txt
@@ -4,3 +4,4 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/lights)
 
 add_subdirectory(ambient_light)
 add_subdirectory(directional_light)
+add_subdirectory(point_light)

--- a/src/lights/point_light/CMakeLists.txt
+++ b/src/lights/point_light/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(raytracer_point_light SHARED
+    PointLight.cpp
+)
+
+target_include_directories(raytracer_point_light PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_point_light PRIVATE
+    -W
+    -Wall
+    -Wextra
+)
+
+set_target_properties(raytracer_point_light PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "raytracer_point_light"
+)

--- a/src/lights/point_light/PointLight.cpp
+++ b/src/lights/point_light/PointLight.cpp
@@ -1,0 +1,22 @@
+#include "PointLight.hpp"
+
+namespace Raytracer
+{
+
+LightSample PointLight::computeLight(const Point3D& hit_point) const
+{
+    Vector3D direction = (_position - hit_point);
+    double distance_squared = direction.length_squared();
+    direction.normalize();
+
+    LightSample sample;
+    double attenuation = _intensity / std::max(1.0, distance_squared);
+    sample.color = _color * attenuation;
+    sample.direction = direction;
+    sample.distance = std::sqrt(distance_squared);
+    sample.isActive = true;
+
+    return sample;
+}
+
+} // namespace Raytracer

--- a/src/lights/point_light/PointLight.hpp
+++ b/src/lights/point_light/PointLight.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "components/ILight.hpp"
+#include "math/Vector3D.hpp"
+#include "math/Color.hpp"
+
+namespace Raytracer
+{
+
+class PointLight : public ILight
+{
+public:
+    PointLight(const Vector3D& position, const Color& color, double intensity)
+        : _position(position), _color(color), _intensity(intensity) {}
+
+    LightSample computeLight(const Point3D& hit_point) const override;
+
+private:
+    Vector3D _position;
+    Color _color;
+    double _intensity;
+};
+
+} // namespace Raytracer


### PR DESCRIPTION
## FIXES

Issue #31 

## Description

Implement the point light class and change the renderer logique to handle every light

### How
- Create point light class with simple ray toward the point
- For each ray check the ray draw by the light and multiply the attenuation with the color of the material

### Testing
1. **Execution**: ./raytracer
2. **Validation**: two sphere with light at the top

### Notes
- **Next**:
- **Technical Details**: 
- **Refactoring**: 
