### PR TITLE
feat(sky): implement sky components and integrate into rendering pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins)
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/primitives)
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/materials)
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/lights)
+file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/skies)
 
 add_compile_options(-fno-gnu-unique)
 

--- a/include/components/ISky.hpp
+++ b/include/components/ISky.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "math/Ray.hpp"
+#include "math/Color.hpp"
+
+#include "components/IPlugin.hpp"
+
+namespace Raytracer
+{
+
+class ISky : public IPlugin
+{
+public:
+    virtual ~ISky() = default;
+
+    /*
+        @brief Get the color of the background in the direction of the ray.
+        @param r The ray for which to get the background color.
+    */
+    virtual Color getBackgroundColor(const Ray& r) const = 0;
+
+    /*
+        @brief Get the color of the environment in the direction of the ray.
+        @param r The ray for which to get the environment color.
+    */
+    virtual Color getEnvironmentColor(const Ray& r) const = 0;
+};
+
+} // namespace Raytracer

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(core)
 add_subdirectory(materials)
 add_subdirectory(lights)
 add_subdirectory(primitives)
+add_subdirectory(skies)
 
 add_executable(raytracer main.cpp)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -8,6 +8,9 @@ add_library(raytracer_core STATIC
     ../primitives/sphere/Sphere.cpp
     ../materials/lambertian/Lambertian.cpp
     ../lights/point_light/PointLight.cpp
+    ../skies/atmospheric_sky/AtmosphericSky.cpp
+    ../skies/empty_sky/EmptySky.cpp
+    ../skies/galaxy_sky/GalaxySky.cpp
 )
 
 target_include_directories(raytracer_core PUBLIC

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -4,6 +4,9 @@
 #include "core/image/Image.hpp"
 #include "materials/lambertian/Lambertian.hpp"
 #include "lights/point_light/PointLight.hpp"
+#include "skies/atmospheric_sky/AtmosphericSky.hpp"
+#include "skies/empty_sky/EmptySky.hpp"
+#include "skies/galaxy_sky/GalaxySky.hpp"
 
 namespace Raytracer
 {
@@ -23,10 +26,14 @@ void Raytracer::run()
     PerspectiveCamera camera(Vector3D::zero(), Vector3D::zero(), 60, 16.0/9.0, 1920, 1080);
     Image _image(camera.getWidth(), camera.getHeight());
     std::shared_ptr<IMaterial> lambertian = std::make_shared<Lambertian>(Color(0.7, 0.3, 0.3));
-
+    
+    auto sky = std::make_unique<AtmosphericSky>(Color(0.5, 0.7, 1.0), Color(1.0, 1.0, 1.0));
+    auto emptySky = std::make_unique<EmptySky>();
+    auto galaxySky = std::make_unique<GalaxySky>();
     auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, -3), 0.5, lambertian);
     auto sphere2 = std::make_shared<Sphere>(Vector3D(1.2, 0, -3), 0.5, lambertian);
     auto light = std::make_shared<PointLight>(Vector3D(1, 1.4, -2), Color(1, 1, 1), .5);
+    _scene.setSky(std::move(galaxySky));
     _scene.addPrimitive(sphere);
     _scene.addPrimitive(sphere2);
     _scene.addLight(light);

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -25,7 +25,7 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
     }
 }
 
-Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {
+Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth, bool isFirstRay) {
     if (depth <= 0) return Color(0, 0, 0);
 
     HitRecord rec;
@@ -36,12 +36,15 @@ Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {
         if (rec.material->scatter(r, rec, attenuation, scattered)) {
             Color direct_light = computeDirectLighting(rec, scene, attenuation);
 
-            return direct_light + attenuation * computeRayColor(scattered, scene, depth - 1);
+            return direct_light + attenuation * computeRayColor(scattered, scene, depth - 1, false);
         }
         return Color(0, 0, 0);
     }
 
-    return scene.getBackground(r);
+    if (!isFirstRay) {
+        return scene.getSky().getEnvironmentColor(r);
+    }
+    return scene.getSky().getBackgroundColor(r);
 }
 
 Color Renderer::computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -22,7 +22,7 @@ public:
 private:
     int _samples;
     int _maxDepth;
-    Color computeRayColor(const Ray& r, const Scene& scene, int depth);
+    Color computeRayColor(const Ray& r, const Scene& scene, int depth, bool isFirstRay = true);
     Color computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation);
 };
 

--- a/src/core/scene/Scene.cpp
+++ b/src/core/scene/Scene.cpp
@@ -3,12 +3,4 @@
 namespace Raytracer
 {
 
-Color Scene::getBackground(const Ray& r) const
-{
-    // Vector3D unit_dir = r.direction().normalized();
-    // double t = 0.5 * (unit_dir.y + 1.0);
-    // return (1.0 - t) * Color(1, 1, 1) + t * _backgroundColor;
-    return _backgroundColor;
-}
-
 } // namespace Raytracer

--- a/src/core/scene/Scene.hpp
+++ b/src/core/scene/Scene.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include "PrimitiveList.hpp"
 #include "components/ILight.hpp"
+#include "components/ISky.hpp"
 #include "math/Color.hpp"
 #include "math/Ray.hpp"
 
@@ -29,12 +30,15 @@ public:
     const IPrimitive& getWorld() const { return _world; }
     const std::vector<std::shared_ptr<ILight>>& getLights() const { return _lights; }
     
-    Color getBackground(const Ray& r) const;
+    void setSky(std::unique_ptr<ISky> sky) { _sky = std::move(sky); }
+    const ISky& getSky() const { return *_sky; }
 
 private:
     PrimitiveList _world;
     
     std::vector<std::shared_ptr<ILight>> _lights;
+
+    std::unique_ptr<ISky> _sky;
     
     Color _backgroundColor = Color(0.5, 0.7, 1.0);
     Color _ambientLight = Color(0.1, 0.1, 0.1);

--- a/src/skies/CMakeLists.txt
+++ b/src/skies/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/skies)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/skies)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/skies)
+
+add_subdirectory(atmospheric_sky)
+add_subdirectory(empty_sky)
+add_subdirectory(galaxy_sky)

--- a/src/skies/atmospheric_sky/AtmosphericSky.cpp
+++ b/src/skies/atmospheric_sky/AtmosphericSky.cpp
@@ -1,0 +1,15 @@
+#include "AtmosphericSky.hpp"
+
+namespace Raytracer
+{
+
+Color AtmosphericSky::getBackgroundColor(const Ray& r) const
+{
+    Vector3D unit_direction = r.direction().normalized();
+
+    double t = 0.5 * (unit_direction.y + 1.0);
+
+    return _groundColor * (1.0 - t) + _zenithColor * t;
+}
+
+} // namespace Raytracer

--- a/src/skies/atmospheric_sky/AtmosphericSky.hpp
+++ b/src/skies/atmospheric_sky/AtmosphericSky.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "skies/commun/ASky.hpp"
+
+namespace Raytracer
+{
+
+class AtmosphericSky : public ASky
+{
+public:
+    AtmosphericSky(const Color& groundColor, const Color& zenithColor)
+        : _groundColor(groundColor), _zenithColor(zenithColor) {}
+
+    Color getBackgroundColor(const Ray& r) const override;
+
+    std::string getName() const override { return "atmospheric_sky"; }
+
+private:
+    Color _groundColor;
+    Color _zenithColor;
+};
+
+} // namespace Raytracer

--- a/src/skies/atmospheric_sky/CMakeLists.txt
+++ b/src/skies/atmospheric_sky/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(raytracer_atmospheric_sky SHARED
+	AtmosphericSky.cpp
+)
+
+target_include_directories(raytracer_atmospheric_sky PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+	${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_atmospheric_sky PRIVATE
+	-W
+	-Wall
+	-Wextra
+)
+
+set_target_properties(raytracer_atmospheric_sky PROPERTIES
+	PREFIX ""
+	OUTPUT_NAME "raytracer_atmospheric_sky"
+)

--- a/src/skies/commun/ASky.hpp
+++ b/src/skies/commun/ASky.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "components/ISky.hpp"
+
+namespace Raytracer
+{
+
+class ASky : public ISky
+{
+public:
+    ASky() = default;
+
+    Color getEnvironmentColor(const Ray& r) const override { return getBackgroundColor(r); }
+};
+
+} // namespace Raytracer

--- a/src/skies/empty_sky/CMakeLists.txt
+++ b/src/skies/empty_sky/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(raytracer_empty_sky SHARED
+	EmptySky.cpp
+)
+
+target_include_directories(raytracer_empty_sky PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+	${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_empty_sky PRIVATE
+	-W
+	-Wall
+	-Wextra
+)
+
+set_target_properties(raytracer_empty_sky PROPERTIES
+	PREFIX ""
+	OUTPUT_NAME "raytracer_empty_sky"
+)

--- a/src/skies/empty_sky/EmptySky.cpp
+++ b/src/skies/empty_sky/EmptySky.cpp
@@ -1,0 +1,1 @@
+#include "EmptySky.hpp"

--- a/src/skies/empty_sky/EmptySky.hpp
+++ b/src/skies/empty_sky/EmptySky.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "skies/commun/ASky.hpp"
+
+namespace Raytracer
+{
+
+class EmptySky : public ASky
+{
+public:
+    EmptySky() = default;
+
+    Color getBackgroundColor([[maybe_unused]] const Ray& r) const override { return Color(0, 0, 0); }
+
+    std::string getName() const override { return "empty_sky"; }
+};
+
+} // namespace Raytracer

--- a/src/skies/galaxy_sky/CMakeLists.txt
+++ b/src/skies/galaxy_sky/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(raytracer_galaxy_sky SHARED
+	GalaxySky.cpp
+)
+
+target_include_directories(raytracer_galaxy_sky PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+	${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_galaxy_sky PRIVATE
+	-W
+	-Wall
+	-Wextra
+)
+
+set_target_properties(raytracer_galaxy_sky PROPERTIES
+	PREFIX ""
+	OUTPUT_NAME "raytracer_galaxy_sky"
+)

--- a/src/skies/galaxy_sky/GalaxySky.cpp
+++ b/src/skies/galaxy_sky/GalaxySky.cpp
@@ -1,0 +1,75 @@
+#include "GalaxySky.hpp"
+#include <cmath>
+#include <algorithm>
+
+namespace Raytracer
+{
+
+double GalaxySky::hash(Vector3D v) const
+{
+    double dot = v.x * 12.9898 + v.y * 78.233 + v.z * 37.719;
+    return std::abs(std::fmod(std::sin(dot) * 43758.5453123, 1.0));
+}
+
+double GalaxySky::noise(Vector3D v) const
+{
+    Vector3D i(std::floor(v.x), std::floor(v.y), std::floor(v.z));
+    Vector3D f(v.x - i.x, v.y - i.y, v.z - i.z);
+
+    f.x = f.x * f.x * (3.0 - 2.0 * f.x);
+    f.y = f.y * f.y * (3.0 - 2.0 * f.y);
+    f.z = f.z * f.z * (3.0 - 2.0 * f.z);
+
+    double n = 
+        hash(i + Vector3D(0,0,0))*(1-f.x)*(1-f.y)*(1-f.z) +
+        hash(i + Vector3D(1,0,0))*f.x*(1-f.y)*(1-f.z) +
+        hash(i + Vector3D(0,1,0))*(1-f.x)*f.y*(1-f.z) +
+        hash(i + Vector3D(1,1,0))*f.x*f.y*(1-f.z) +
+        hash(i + Vector3D(0,0,1))*(1-f.x)*(1-f.y)*f.z +
+        hash(i + Vector3D(1,0,1))*f.x*(1-f.y)*f.z +
+        hash(i + Vector3D(0,1,1))*(1-f.x)*f.y*f.z +
+        hash(i + Vector3D(1,1,1))*f.x*f.y*f.z;
+    return n;
+}
+
+Color GalaxySky::getBackgroundColor(const Ray& r) const
+{
+    Vector3D unit_dir = r.direction().normalized();
+
+    double fbm = 0.0;
+    double amplitude = 0.5;
+    Vector3D p = unit_dir * 3.0;
+    
+    for (int i = 0; i < 4; ++i) {
+        fbm += amplitude * noise(p);
+        p = p * 2.0;
+        amplitude *= 0.5;
+    }
+
+    double threshold = 1.0 - _nebulaDensity;
+    double nebulaValue = std::max(0.0, fbm - threshold);
+    double nebulaStrength = std::pow(nebulaValue, _nebulaContrast); 
+    
+    Color finalColor = _nebulaColor * nebulaStrength;
+
+    double gridSize = 1000.0;
+    Vector3D cell(std::floor(unit_dir.x * gridSize),
+                  std::floor(unit_dir.y * gridSize),
+                  std::floor(unit_dir.z * gridSize));
+    
+    double starRand = hash(cell);
+
+    if (starRand > 1.0 - _starDensity) {
+        double intensity = (starRand - (1.0 - _starDensity)) / _starDensity;
+        return finalColor + Color(1.0, 1.0, 1.0) * std::pow(intensity, 2.0);
+    }
+
+    return finalColor;
+}
+
+Color GalaxySky::getEnvironmentColor([[maybe_unused]]const Ray& r) const
+{
+    return _nebulaColor * 0.8;
+}
+
+} // namespace Raytracer

--- a/src/skies/galaxy_sky/GalaxySky.hpp
+++ b/src/skies/galaxy_sky/GalaxySky.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "skies/commun/ASky.hpp"
+
+namespace Raytracer
+{
+
+class GalaxySky : public ASky
+{
+public:
+    GalaxySky(double starDensity = 0.001, const Color& nebulaColor = Color(0.025, 0.01, 0.05), double nebulaDensity = 0.7, double nebulaContrast = 3.0)
+            : _starDensity(starDensity), _nebulaColor(nebulaColor), _nebulaDensity(nebulaDensity), _nebulaContrast(nebulaContrast) {}
+
+    Color getBackgroundColor(const Ray& r) const override;
+    Color getEnvironmentColor(const Ray& r) const override;
+
+    std::string getName() const override { return "galaxy_sky"; }
+
+private:
+    double _starDensity;
+    Color _nebulaColor;
+    double _nebulaDensity;
+    double _nebulaContrast;
+
+    double hash(Vector3D v) const;
+    double noise(Vector3D v) const;
+};
+
+} // namespace Raytracer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_subdirectory(primitives)
 add_subdirectory(lights)
 add_subdirectory(materials)
 add_subdirectory(core)
+add_subdirectory(skies)
 
 target_include_directories(raytracer_unit_tests PRIVATE
     ${PROJECT_SOURCE_DIR}/include

--- a/tests/scene/scene_tests.cpp
+++ b/tests/scene/scene_tests.cpp
@@ -46,19 +46,6 @@ public:
 
 } // namespace
 
-TEST(Scene, BackgroundColorCanBeUpdated)
-{
-    Raytracer::Scene scene;
-    const Raytracer::Color expected{0.2, 0.3, 0.4};
-
-    scene.setBackgroundColor(expected);
-    const Raytracer::Color actual = scene.getBackground({{0.0, 0.0, 0.0}, {0.0, 1.0, 0.0}});
-
-    EXPECT_DOUBLE_EQ(actual.r, expected.r);
-    EXPECT_DOUBLE_EQ(actual.g, expected.g);
-    EXPECT_DOUBLE_EQ(actual.b, expected.b);
-}
-
 TEST(Scene, AddedLightIsExposedByGetter)
 {
     Raytracer::Scene scene;

--- a/tests/skies/CMakeLists.txt
+++ b/tests/skies/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(raytracer_unit_tests PRIVATE
+    skies_tests.cpp
+)

--- a/tests/skies/skies_tests.cpp
+++ b/tests/skies/skies_tests.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include "math/Color.hpp"
+#include "math/Ray.hpp"
+#include "skies/atmospheric_sky/AtmosphericSky.hpp"
+#include "skies/empty_sky/EmptySky.hpp"
+#include "skies/galaxy_sky/GalaxySky.hpp"
+
+namespace
+{
+
+void expectColorNear(const Raytracer::Color& actual,
+                     const Raytracer::Color& expected,
+                     double epsilon = 1e-12)
+{
+    EXPECT_NEAR(actual.r, expected.r, epsilon);
+    EXPECT_NEAR(actual.g, expected.g, epsilon);
+    EXPECT_NEAR(actual.b, expected.b, epsilon);
+}
+
+} // namespace
+
+TEST(EmptySky, ReturnsBlackBackground)
+{
+    Raytracer::EmptySky sky;
+    const Raytracer::Ray ray({0.0, 0.0, 0.0}, {1.0, 0.0, 0.0});
+
+    expectColorNear(sky.getBackgroundColor(ray), {0.0, 0.0, 0.0});
+    expectColorNear(sky.getEnvironmentColor(ray), {0.0, 0.0, 0.0});
+    EXPECT_EQ(sky.getName(), "empty_sky");
+}
+
+TEST(AtmosphericSky, InterpolatesBetweenGroundAndZenith)
+{
+    const Raytracer::Color ground{0.5, 0.7, 1.0};
+    const Raytracer::Color zenith{1.0, 1.0, 1.0};
+    Raytracer::AtmosphericSky sky(ground, zenith);
+
+    EXPECT_EQ(sky.getName(), "atmospheric_sky");
+
+    const Raytracer::Ray up_ray({0.0, 0.0, 0.0}, {0.0, 1.0, 0.0});
+    const Raytracer::Ray down_ray({0.0, 0.0, 0.0}, {0.0, -1.0, 0.0});
+    const Raytracer::Ray horizon_ray({0.0, 0.0, 0.0}, {1.0, 0.0, 0.0});
+
+    expectColorNear(sky.getBackgroundColor(up_ray), zenith);
+    expectColorNear(sky.getEnvironmentColor(up_ray), zenith);
+    expectColorNear(sky.getBackgroundColor(down_ray), ground);
+    expectColorNear(sky.getEnvironmentColor(down_ray), ground);
+    expectColorNear(sky.getBackgroundColor(horizon_ray), {0.75, 0.85, 1.0});
+}
+
+TEST(GalaxySky, ZeroStarAndNebulaDensityGivesBlackBackground)
+{
+    const Raytracer::Color nebulaColor{0.2, 0.4, 0.6};
+    Raytracer::GalaxySky sky(0.0, nebulaColor, 0.0, 3.0);
+    const Raytracer::Ray ray({0.0, 0.0, 0.0}, {0.3, 0.4, 0.5});
+
+    EXPECT_EQ(sky.getName(), "galaxy_sky");
+    expectColorNear(sky.getBackgroundColor(ray), {0.0, 0.0, 0.0});
+    expectColorNear(sky.getEnvironmentColor(ray), nebulaColor * 0.8);
+}
+
+TEST(GalaxySky, BackgroundColorIsDeterministic)
+{
+    Raytracer::GalaxySky sky(0.001, {0.025, 0.01, 0.05}, 0.7, 3.0);
+    const Raytracer::Ray ray({0.0, 0.0, 0.0}, {0.2, 0.8, -0.4});
+
+    const Raytracer::Color first = sky.getBackgroundColor(ray);
+    const Raytracer::Color second = sky.getBackgroundColor(ray);
+
+    expectColorNear(first, second);
+}


### PR DESCRIPTION
## FIXES

Issue #51 

## Description

Implement the sky interface and add it in the renderer loop with three sky possible

### How
- Create a interface with two function, one is for drawing the sky and the other one is for the color that the sky emit
- Call the function of the sky depending if its a ray from a primitive or from the camera
- Implement three sky, one is pur black, one is blue and the last is a simulation of the galaxy with perlin noise

### Testing
1. **Execution**: ./raytracer
2. **Validation**: see a galaxy like sky with purple ambiant light

### Notes
- **Next**: Add more sky and implement in the parser and the factory the ISky
