### PR TITLE
Feat/material/transparent

### DIFF
--- a/include/components/IMaterial.hpp
+++ b/include/components/IMaterial.hpp
@@ -20,6 +20,12 @@ public:
         Color& attenuation,
         Ray& scattered
     ) const = 0;
+
+    virtual double getSpecularWeight() const = 0;
+
+    virtual Color getTransmittance() const = 0;
+
+    virtual Color emit(const HitRecord& rec) const = 0;
 };
 
 } // namespace Raytracer

--- a/include/math/Color.hpp
+++ b/include/math/Color.hpp
@@ -29,7 +29,7 @@ struct Color
         return *this;
     }
 
-    [[nodiscard]] bool near_zero() const noexcept {
+    [[nodiscard]] bool isNearZero() const noexcept {
         const auto s = 1e-8;
         return (std::fabs(r) < s) && (std::fabs(g) < s) && (std::fabs(b) < s);
     }

--- a/include/math/Color.hpp
+++ b/include/math/Color.hpp
@@ -29,6 +29,11 @@ struct Color
         return *this;
     }
 
+    [[nodiscard]] bool near_zero() const noexcept {
+        const auto s = 1e-8;
+        return (std::fabs(r) < s) && (std::fabs(g) < s) && (std::fabs(b) < s);
+    }
+
     static int to_byte(double value) noexcept {
         static const Interval intensity(0.0, 0.999);
         return static_cast<int>(256 * intensity.clamp(std::sqrt(value)));

--- a/include/math/MathUtils.hpp
+++ b/include/math/MathUtils.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <random>
+
 #include "math/Vector3D.hpp"
 
 namespace Raytracer

--- a/include/math/MathUtils.hpp
+++ b/include/math/MathUtils.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <random>
+#include "math/Vector3D.hpp"
 
 namespace Raytracer
 {
@@ -30,6 +31,39 @@ public:
         static std::uniform_real_distribution<double> distribution(min, max);
         static std::mt19937 generator;
         return distribution(generator);
+    }
+
+    /**
+     * @brief Calculate the reflection of a vector on a normal
+     */
+    static inline Vector3D reflect(const Vector3D& v, const Vector3D& n) {
+        return v - n * (2.0 * v.dot(n));
+    }
+
+    /**
+     * @brief Calculate refraction according to Snell-Descartes law
+     * @param uv The incident vector (must be normalized)
+     * @param n The surface normal
+     * @param etai_over_etat The ratio of refractive indices
+     */
+    static inline Vector3D refract(const Vector3D& uv, const Vector3D& n, double etai_over_etat) {
+        double cos_theta = std::min((-uv).dot(n), 1.0);
+        
+        Vector3D r_out_perp = (uv + n * cos_theta) * etai_over_etat;
+        
+        double r_out_parallel_len = -std::sqrt(std::abs(1.0 - r_out_perp.length_squared()));
+        Vector3D r_out_parallel = n * r_out_parallel_len;
+        
+        return r_out_perp + r_out_parallel;
+    }
+
+    /**
+     * @brief Schlick approximation for reflectance (Fresnel effect)
+     */
+    static inline double reflectance(double cosine, double ref_idx) {
+        double r0 = (1.0 - ref_idx) / (1.0 + ref_idx);
+        r0 = r0 * r0;
+        return r0 + (1.0 - r0) * std::pow((1.0 - cosine), 5.0);
     }
 };
 

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -76,7 +76,7 @@ struct Vector3D
         return Vector3D(x * inv, y * inv, z * inv);
     }
 
-    [[nodiscard]] bool near_zero() const noexcept {
+    [[nodiscard]] bool isNearZero() const noexcept {
         const auto s = 1e-8;
         return (std::fabs(x) < s) && (std::fabs(y) < s) && (std::fabs(z) < s);
     }

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -2,8 +2,7 @@
 
 #include <cmath>
 #include <iostream>
-
-#include "math/MathUtils.hpp"
+#include <random>
 
 namespace Raytracer
 {
@@ -93,10 +92,17 @@ struct Vector3D
     static constexpr Vector3D left()     noexcept { return {-1, 0, 0}; }
     static constexpr Vector3D forward()  noexcept { return {0, 0, -1}; }
     static constexpr Vector3D back()     noexcept { return {0, 0, 1}; }
+
+    static double random_double(double min, double max) {
+        static std::mt19937 generator(std::random_device{}());
+        std::uniform_real_distribution<double> distribution(min, max);
+        return distribution(generator);
+    }
+
     static Vector3D random() {
-        return Vector3D(Math::random_double(-1, 1), 
-                        Math::random_double(-1, 1), 
-                        Math::random_double(-1, 1));
+        return Vector3D(random_double(-1, 1),
+                        random_double(-1, 1),
+                        random_double(-1, 1));
     }
     static Vector3D random_unit_vector() {
         while (true) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(raytracer_core STATIC
     image/Image.cpp
     ../primitives/sphere/Sphere.cpp
     ../materials/lambertian/Lambertian.cpp
+    ../materials/transparent/Transparent.cpp
     ../lights/point_light/PointLight.cpp
     ../skies/atmospheric_sky/AtmosphericSky.cpp
     ../skies/empty_sky/EmptySky.cpp

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -3,6 +3,7 @@
 #include "primitives/sphere/Sphere.hpp"
 #include "core/image/Image.hpp"
 #include "materials/lambertian/Lambertian.hpp"
+#include "materials/transparent/Transparent.hpp"
 #include "lights/point_light/PointLight.hpp"
 #include "skies/atmospheric_sky/AtmosphericSky.hpp"
 #include "skies/empty_sky/EmptySky.hpp"
@@ -23,19 +24,25 @@ void Raytracer::run()
         return;
 
     FrameBuffer frameBuffer;
-    PerspectiveCamera camera(Vector3D::zero(), Vector3D::zero(), 60, 16.0/9.0, 1920, 1080);
+    PerspectiveCamera camera(Vector3D(0, 1.5f, 0), Vector3D(-25, 0, 0), 60, 16.0/9.0, 1920, 1080);
     Image _image(camera.getWidth(), camera.getHeight());
-    std::shared_ptr<IMaterial> lambertian = std::make_shared<Lambertian>(Color(0.7, 0.3, 0.3));
-    
-    auto sky = std::make_unique<AtmosphericSky>(Color(0.5, 0.7, 1.0), Color(1.0, 1.0, 1.0));
+    std::shared_ptr<IMaterial> lambertianRed = std::make_shared<Lambertian>(Color(0.7, 0.3, 0.3));
+    std::shared_ptr<IMaterial> lambertianGreen = std::make_shared<Lambertian>(Color(0.3, 0.7, 0.3));
+    std::shared_ptr<IMaterial> transparent = std::make_shared<Transparent>(Color(0.8, 0.8, 0.8), 0.8);
+
+    auto sky = std::make_unique<AtmosphericSky>(Color(0.5, 0.7, 1.0), Color(0.5, 0.5, 0.5));
     auto emptySky = std::make_unique<EmptySky>();
     auto galaxySky = std::make_unique<GalaxySky>();
-    auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, -3), 0.5, lambertian);
-    auto sphere2 = std::make_shared<Sphere>(Vector3D(1.2, 0, -3), 0.5, lambertian);
+    auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, -3), 0.5, lambertianRed);
+    auto sphere2 = std::make_shared<Sphere>(Vector3D(1.2, 0, -3), 0.5, lambertianRed);
+    auto sphere3 = std::make_shared<Sphere>(Vector3D(-0.5, 0, -2), 0.5, transparent);
+    auto bigSphere = std::make_shared<Sphere>(Vector3D(0, -100.5, -1), 100, lambertianGreen);
     auto light = std::make_shared<PointLight>(Vector3D(1, 1.4, -2), Color(1, 1, 1), .5);
-    _scene.setSky(std::move(galaxySky));
+    _scene.setSky(std::move(sky));
     _scene.addPrimitive(sphere);
     _scene.addPrimitive(sphere2);
+    _scene.addPrimitive(sphere3);
+    _scene.addPrimitive(bigSphere);
     _scene.addLight(light);
     _scene.setBackgroundColor(Color(0, 0, 0));
 

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -1,5 +1,6 @@
 #include "Renderer.hpp"
 #include "components/IMaterial.hpp"
+#include "math/Color.hpp"
 
 namespace Raytracer
 {
@@ -29,40 +30,60 @@ Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth, boo
     if (depth <= 0) return Color(0, 0, 0);
 
     HitRecord rec;
-    if (scene.getWorld().hit(r, Interval(0.001, Interval::universe.max), rec)) {
+    if (scene.getWorld().hit(r, Interval(0.001, std::numeric_limits<double>::max()), rec)) {
         Ray scattered;
         Color attenuation;
 
+        Color emitted = rec.material->emit(rec);
+
         if (rec.material->scatter(r, rec, attenuation, scattered)) {
-            Color direct_light = computeDirectLighting(rec, scene, attenuation);
+            double specWeight = rec.material->getSpecularWeight();
+            double diffuseWeight = 1.0 - specWeight;
 
-            return direct_light + attenuation * computeRayColor(scattered, scene, depth - 1, false);
+            Color direct_light(0, 0, 0);
+            if (diffuseWeight > 0) {
+                direct_light = computeDirectLighting(rec, scene, attenuation) * diffuseWeight;
+            }
+            return emitted + direct_light + attenuation * computeRayColor(scattered, scene, depth - 1, false);
         }
-        return Color(0, 0, 0);
+        return emitted;
     }
 
-    if (!isFirstRay) {
-        return scene.getSky().getEnvironmentColor(r);
-    }
-    return scene.getSky().getBackgroundColor(r);
+    return isFirstRay ? scene.getSky().getBackgroundColor(r) : scene.getSky().getEnvironmentColor(r);
 }
 
 Color Renderer::computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)
 {
-    Color direct_light(0, 0, 0);
+    Color total_direct_light(0, 0, 0);
+
     for (const auto& light : scene.getLights()) {
         LightSample sample = light->computeLight(rec.point);
         if (!sample.isActive) continue;
 
         Ray shadow_ray(rec.point + rec.normal * 0.001, sample.direction);
-        HitRecord shadow_rec;
+        Color light_visibility(1.0, 1.0, 1.0);
+        double t_min = 0.001;
 
-        if (!scene.getWorld().hit(shadow_ray, Interval(0.001, sample.distance), shadow_rec)) {
+        HitRecord shadow_rec;
+        while (scene.getWorld().hit(shadow_ray, Interval(t_min, sample.distance), shadow_rec)) {
+            Color transmittance = shadow_rec.material->getTransmittance();
+            
+            light_visibility *= transmittance;
+
+            if (light_visibility.isNearZero()) {
+                light_visibility = Color(0, 0, 0);
+                break;
+            }
+
+            t_min = shadow_rec.t + 0.001;
+        }
+
+        if (!light_visibility.isNearZero()) {
             double cos_theta = std::max(0.0, rec.normal.dot(sample.direction));
-            direct_light += (attenuation * sample.color) * cos_theta;
+            total_direct_light += (attenuation * sample.color * light_visibility) * cos_theta;
         }
     }
-    return direct_light;
+    return total_direct_light;
 }
 
 } // namespace Raytracer

--- a/src/materials/commun/AMaterial.hpp
+++ b/src/materials/commun/AMaterial.hpp
@@ -7,8 +7,12 @@ namespace Raytracer
 
 class AMaterial : public IMaterial
 {
-protected:
-    AMaterial() = default;
+public:
+    double getSpecularWeight() const override { return 0.0; }
+
+    Color getTransmittance() const override { return Color(0, 0, 0); }
+
+    Color emit(const HitRecord& rec) const override { return Color(0, 0, 0); }
 };
 
 } // namespace Raytracer

--- a/src/materials/commun/AMaterial.hpp
+++ b/src/materials/commun/AMaterial.hpp
@@ -12,7 +12,7 @@ public:
 
     Color getTransmittance() const override { return Color(0, 0, 0); }
 
-    Color emit(const HitRecord& rec) const override { return Color(0, 0, 0); }
+    Color emit([[maybe_unused]] const HitRecord& rec) const override { return Color(0, 0, 0); }
 };
 
 } // namespace Raytracer

--- a/src/materials/commun/AMaterial.hpp
+++ b/src/materials/commun/AMaterial.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "components/IMaterial.hpp"
+
+namespace Raytracer
+{
+
+class AMaterial : public IMaterial
+{
+protected:
+    AMaterial() = default;
+};
+
+} // namespace Raytracer

--- a/src/materials/lambertian/Lambertian.cpp
+++ b/src/materials/lambertian/Lambertian.cpp
@@ -15,7 +15,7 @@ bool Lambertian::scatter(
 ) const
 {
     auto scatter_direction = rec.normal + Vector3D::random_unit_vector();
-    if (scatter_direction.near_zero())
+    if (scatter_direction.isNearZero())
         scatter_direction = rec.normal;
 
     scattered = Ray(rec.point, scatter_direction);

--- a/src/materials/lambertian/Lambertian.hpp
+++ b/src/materials/lambertian/Lambertian.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "components/IMaterial.hpp"
+#include "materials/commun/AMaterial.hpp"
 
 namespace Raytracer
 {
 
-class Lambertian : public IMaterial
+class Lambertian : public AMaterial
 {
 public:
     Lambertian(const Color& albedo);

--- a/src/materials/transparent/CMakeLists.txt
+++ b/src/materials/transparent/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(raytracer_transparent SHARED
+    Transparent.cpp
+)
+
+target_include_directories(raytracer_transparent PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_transparent PRIVATE
+    -W
+    -Wall
+    -Wextra
+)
+
+set_target_properties(raytracer_transparent PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "raytracer_transparent"
+)

--- a/src/materials/transparent/Transparent.cpp
+++ b/src/materials/transparent/Transparent.cpp
@@ -1,0 +1,29 @@
+#include "Transparent.hpp"
+#include "math/MathUtils.hpp"
+
+namespace Raytracer
+{
+
+bool Transparent::scatter(const Ray& r_in, const HitRecord& rec, Color& attenuation, Ray& scattered) const
+{
+    attenuation = _albedo;
+    double ratio = rec.front_face ? (1.0 / _ref_idx) : _ref_idx;
+
+    Vector3D unit_direction = r_in.direction().normalized();
+    double cos_theta = std::min((-unit_direction).dot(rec.normal), 1.0);
+    double sin_theta = std::sqrt(1.0 - cos_theta * cos_theta);
+
+    bool cannot_refract = ratio * sin_theta > 1.0;
+    Vector3D direction;
+
+    if (cannot_refract || Math::reflectance(cos_theta, ratio) > Math::random_double(0.0, 1.0)) {
+        direction = Math::reflect(unit_direction, rec.normal);
+    } else {
+        direction = Math::refract(unit_direction, rec.normal, ratio);
+    }
+
+    scattered = Ray(rec.point, direction);
+    return true;
+}
+
+} // namespace Raytracer

--- a/src/materials/transparent/Transparent.hpp
+++ b/src/materials/transparent/Transparent.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "materials/commun/AMaterial.hpp"
+
+namespace Raytracer
+{
+
+class Transparent : public AMaterial
+{
+public:
+    Transparent(Color albedo, double ref_idx): 
+        _albedo(albedo), _ref_idx(ref_idx) {}
+
+    bool scatter(
+        const Ray& r_in,
+        const HitRecord& rec,
+        Color& attenuation,
+        Ray& scattered
+    ) const override;
+    
+    double getSpecularWeight() const override { return 1.0; }
+    
+    Color getTransmittance() const override { return _albedo; }
+
+    virtual std::string getName() const override { return "transparent"; }
+
+private:
+    Color _albedo;
+    double _ref_idx;
+};
+
+} // namespace Raytracer

--- a/tests/materials/materials_tests.cpp
+++ b/tests/materials/materials_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "materials/lambertian/Lambertian.hpp"
+#include "materials/transparent/Transparent.hpp"
 #include "math/Ray.hpp"
 #include "math/HitRecord.hpp"
 #include "math/Vector3D.hpp"
@@ -93,4 +94,43 @@ TEST(Lambertian, GetName)
     Raytracer::Lambertian material({0.8, 0.8, 0.8});
 
     EXPECT_EQ(material.getName(), "lambertian");
+}
+
+// Transparent tests
+TEST(Transparent, BasicProperties)
+{
+    Raytracer::Transparent material({0.9, 0.8, 0.7}, 1.5);
+
+    EXPECT_EQ(material.getName(), "transparent");
+    EXPECT_DOUBLE_EQ(material.getSpecularWeight(), 1.0);
+
+    Raytracer::Color transmittance = material.getTransmittance();
+    EXPECT_DOUBLE_EQ(transmittance.r, 0.9);
+    EXPECT_DOUBLE_EQ(transmittance.g, 0.8);
+    EXPECT_DOUBLE_EQ(transmittance.b, 0.7);
+}
+
+TEST(Transparent, ScatterUsesReflectionWhenCannotRefract)
+{
+    Raytracer::Transparent material({0.7, 0.8, 0.9}, 1.5);
+
+    Raytracer::Ray ray_in({0.0, 0.0, 0.0}, {0.8, 0.0, -0.6});
+    Raytracer::HitRecord rec;
+    rec.point = {1.0, 2.0, 3.0};
+    rec.normal = {0.0, 0.0, 1.0};
+    rec.front_face = false;
+
+    Raytracer::Color attenuation;
+    Raytracer::Ray scattered;
+
+    bool result = material.scatter(ray_in, rec, attenuation, scattered);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(attenuation.r, 0.7);
+    EXPECT_DOUBLE_EQ(attenuation.g, 0.8);
+    EXPECT_DOUBLE_EQ(attenuation.b, 0.9);
+    expectVectorNear(scattered.origin(), rec.point);
+
+    Raytracer::Vector3D expected = {0.8, 0.0, 0.6};
+    expectVectorNear(scattered.direction(), expected);
 }

--- a/tests/math/math_tests.cpp
+++ b/tests/math/math_tests.cpp
@@ -61,8 +61,8 @@ TEST(Vector3D, NearZero)
     const Raytracer::Vector3D small{1e-10, -1e-11, 9e-10};
     const Raytracer::Vector3D large{1e-4, 0.0, 0.0};
 
-    EXPECT_TRUE(small.near_zero());
-    EXPECT_FALSE(large.near_zero());
+    EXPECT_TRUE(small.isNearZero());
+    EXPECT_FALSE(large.isNearZero());
 }
 
 TEST(Ray, At)


### PR DESCRIPTION
## FIXES

Issue #53 

## Description

Add the transparent material and update the renderer to have corresponding shadow for the transparent

### How
- Create a abstract material class to have global getter
- Add getter for the transmittance to allow light ray to pass trought
- Add getter for the specular to process the direct light on the material or not
- Create the transparent material with reflexion indice to reflect or refract the ray with albedo

### Testing
1. **Execution**: ./raytracer
2. **Validation**: A glass ball with reflection of the ground and the other sphere

### Notes
- **Next**: Implement the mirror material
- **Technical Details**: Need antialiasing to remove the noise
