### PR TITLE
Feat/core/antialiasing

### DIFF
--- a/include/components/IMaterial.hpp
+++ b/include/components/IMaterial.hpp
@@ -20,6 +20,12 @@ public:
         Color& attenuation,
         Ray& scattered
     ) const = 0;
+
+    virtual double getSpecularWeight() const = 0;
+
+    virtual Color getTransmittance() const = 0;
+
+    virtual Color emit(const HitRecord& rec) const = 0;
 };
 
 } // namespace Raytracer

--- a/include/math/Color.hpp
+++ b/include/math/Color.hpp
@@ -29,7 +29,7 @@ struct Color
         return *this;
     }
 
-    [[nodiscard]] bool near_zero() const noexcept {
+    [[nodiscard]] bool isNearZero() const noexcept {
         const auto s = 1e-8;
         return (std::fabs(r) < s) && (std::fabs(g) < s) && (std::fabs(b) < s);
     }

--- a/include/math/Color.hpp
+++ b/include/math/Color.hpp
@@ -29,6 +29,11 @@ struct Color
         return *this;
     }
 
+    [[nodiscard]] bool near_zero() const noexcept {
+        const auto s = 1e-8;
+        return (std::fabs(r) < s) && (std::fabs(g) < s) && (std::fabs(b) < s);
+    }
+
     static int to_byte(double value) noexcept {
         static const Interval intensity(0.0, 0.999);
         return static_cast<int>(256 * intensity.clamp(std::sqrt(value)));

--- a/include/math/Color.hpp
+++ b/include/math/Color.hpp
@@ -34,7 +34,7 @@ struct Color
         return (std::fabs(r) < s) && (std::fabs(g) < s) && (std::fabs(b) < s);
     }
 
-    static int to_byte(double value) noexcept {
+    static int toByte(double value) noexcept {
         static const Interval intensity(0.0, 0.999);
         return static_cast<int>(256 * intensity.clamp(std::sqrt(value)));
     }

--- a/include/math/HitRecord.hpp
+++ b/include/math/HitRecord.hpp
@@ -22,7 +22,7 @@ struct HitRecord
     
     std::shared_ptr<IMaterial> material;
 
-    inline void set_face_normal(const Ray& r, const Vector3D& outward_normal) noexcept {
+    inline void setFaceNormal(const Ray& r, const Vector3D& outward_normal) noexcept {
         front_face = r.direction().dot(outward_normal) < 0;
         normal = front_face ? outward_normal : -outward_normal;
     }

--- a/include/math/MathUtils.hpp
+++ b/include/math/MathUtils.hpp
@@ -28,7 +28,7 @@ public:
     /**
      * @brief Generate a random double precision floating point number in the range [min, max)
      */
-    static inline double random_double(double min, double max) {
+    static inline double randomDouble(double min, double max) {
         static std::uniform_real_distribution<double> distribution(min, max);
         static std::mt19937 generator;
         return distribution(generator);
@@ -52,7 +52,7 @@ public:
         
         Vector3D r_out_perp = (uv + n * cos_theta) * etai_over_etat;
         
-        double r_out_parallel_len = -std::sqrt(std::abs(1.0 - r_out_perp.length_squared()));
+        double r_out_parallel_len = -std::sqrt(std::abs(1.0 - r_out_perp.lengthSquared()));
         Vector3D r_out_parallel = n * r_out_parallel_len;
         
         return r_out_perp + r_out_parallel;

--- a/include/math/MathUtils.hpp
+++ b/include/math/MathUtils.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <random>
+
 #include "math/Vector3D.hpp"
 
 namespace Raytracer

--- a/include/math/MathUtils.hpp
+++ b/include/math/MathUtils.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <random>
+#include "math/Vector3D.hpp"
 
 namespace Raytracer
 {
@@ -30,6 +31,39 @@ public:
         static std::uniform_real_distribution<double> distribution(min, max);
         static std::mt19937 generator;
         return distribution(generator);
+    }
+
+    /**
+     * @brief Calculate the reflection of a vector on a normal
+     */
+    static inline Vector3D reflect(const Vector3D& v, const Vector3D& n) {
+        return v - n * (2.0 * v.dot(n));
+    }
+
+    /**
+     * @brief Calculate refraction according to Snell-Descartes law
+     * @param uv The incident vector (must be normalized)
+     * @param n The surface normal
+     * @param etai_over_etat The ratio of refractive indices
+     */
+    static inline Vector3D refract(const Vector3D& uv, const Vector3D& n, double etai_over_etat) {
+        double cos_theta = std::min((-uv).dot(n), 1.0);
+        
+        Vector3D r_out_perp = (uv + n * cos_theta) * etai_over_etat;
+        
+        double r_out_parallel_len = -std::sqrt(std::abs(1.0 - r_out_perp.length_squared()));
+        Vector3D r_out_parallel = n * r_out_parallel_len;
+        
+        return r_out_perp + r_out_parallel;
+    }
+
+    /**
+     * @brief Schlick approximation for reflectance (Fresnel effect)
+     */
+    static inline double reflectance(double cosine, double ref_idx) {
+        double r0 = (1.0 - ref_idx) / (1.0 + ref_idx);
+        r0 = r0 * r0;
+        return r0 + (1.0 - r0) * std::pow((1.0 - cosine), 5.0);
     }
 };
 

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -93,16 +93,16 @@ struct Vector3D
     static constexpr Vector3D forward()  noexcept { return {0, 0, -1}; }
     static constexpr Vector3D back()     noexcept { return {0, 0, 1}; }
 
-    static double random_double(double min, double max) {
+    static double getRandomDouble(double min, double max) {
         static std::mt19937 generator(std::random_device{}());
         std::uniform_real_distribution<double> distribution(min, max);
         return distribution(generator);
     }
 
     static Vector3D random() {
-        return Vector3D(random_double(-1, 1),
-                        random_double(-1, 1),
-                        random_double(-1, 1));
+        return Vector3D(getRandomDouble(-1, 1),
+                        getRandomDouble(-1, 1),
+                        getRandomDouble(-1, 1));
     }
     static Vector3D random_unit_vector() {
         while (true) {

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -76,7 +76,7 @@ struct Vector3D
         return Vector3D(x * inv, y * inv, z * inv);
     }
 
-    [[nodiscard]] bool near_zero() const noexcept {
+    [[nodiscard]] bool isNearZero() const noexcept {
         const auto s = 1e-8;
         return (std::fabs(x) < s) && (std::fabs(y) < s) && (std::fabs(z) < s);
     }

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -2,8 +2,7 @@
 
 #include <cmath>
 #include <iostream>
-
-#include "math/MathUtils.hpp"
+#include <random>
 
 namespace Raytracer
 {
@@ -93,10 +92,17 @@ struct Vector3D
     static constexpr Vector3D left()     noexcept { return {-1, 0, 0}; }
     static constexpr Vector3D forward()  noexcept { return {0, 0, -1}; }
     static constexpr Vector3D back()     noexcept { return {0, 0, 1}; }
+
+    static double random_double(double min, double max) {
+        static std::mt19937 generator(std::random_device{}());
+        std::uniform_real_distribution<double> distribution(min, max);
+        return distribution(generator);
+    }
+
     static Vector3D random() {
-        return Vector3D(Math::random_double(-1, 1), 
-                        Math::random_double(-1, 1), 
-                        Math::random_double(-1, 1));
+        return Vector3D(random_double(-1, 1),
+                        random_double(-1, 1),
+                        random_double(-1, 1));
     }
     static Vector3D random_unit_vector() {
         while (true) {

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -52,8 +52,8 @@ struct Vector3D
         return (x == v.x && y == v.y && z == v.z);
     }
 
-    [[nodiscard]] double length_squared() const noexcept { return x*x + y*y + z*z; }
-    [[nodiscard]] double length() const noexcept { return std::sqrt(length_squared()); }
+    [[nodiscard]] double lengthSquared() const noexcept { return x*x + y*y + z*z; }
+    [[nodiscard]] double length() const noexcept { return std::sqrt(lengthSquared()); }
 
     [[nodiscard]] double dot(const Vector3D& v) const noexcept {
         return x * v.x + y * v.y + z * v.z;
@@ -82,9 +82,9 @@ struct Vector3D
     }
 
     static constexpr Vector3D zero()     noexcept { return {0, 0, 0}; }
-    static constexpr Vector3D unit_x()   noexcept { return {1, 0, 0}; }
-    static constexpr Vector3D unit_y()   noexcept { return {0, 1, 0}; }
-    static constexpr Vector3D unit_z()   noexcept { return {0, 0, 1}; }
+    static constexpr Vector3D unitX()   noexcept { return {1, 0, 0}; }
+    static constexpr Vector3D unitY()   noexcept { return {0, 1, 0}; }
+    static constexpr Vector3D unitZ()   noexcept { return {0, 0, 1}; }
 
     static constexpr Vector3D up()       noexcept { return {0, 1, 0}; }
     static constexpr Vector3D down()     noexcept { return {0, -1, 0}; }
@@ -104,10 +104,10 @@ struct Vector3D
                         getRandomDouble(-1, 1),
                         getRandomDouble(-1, 1));
     }
-    static Vector3D random_unit_vector() {
+    static Vector3D getRandomUnitVector() {
         while (true) {
             auto p = Vector3D::random();
-            auto lensq = p.length_squared();
+            auto lensq = p.lengthSquared();
             
             if (lensq > 1e-160 && lensq <= 1.0) {
                 return p / std::sqrt(lensq);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(raytracer_core STATIC
     image/Image.cpp
     ../primitives/sphere/Sphere.cpp
     ../materials/lambertian/Lambertian.cpp
+    ../materials/transparent/Transparent.cpp
     ../lights/point_light/PointLight.cpp
     ../skies/atmospheric_sky/AtmosphericSky.cpp
     ../skies/empty_sky/EmptySky.cpp

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -46,6 +46,7 @@ void Raytracer::run()
     _scene.addLight(light);
     _scene.setBackgroundColor(Color(0, 0, 0));
 
+    _renderer.setSamples(1);
     _renderer.render(camera, _scene, frameBuffer);
     _image.drawFromBuffer(frameBuffer);
 }

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -3,6 +3,7 @@
 #include "primitives/sphere/Sphere.hpp"
 #include "core/image/Image.hpp"
 #include "materials/lambertian/Lambertian.hpp"
+#include "materials/transparent/Transparent.hpp"
 #include "lights/point_light/PointLight.hpp"
 #include "skies/atmospheric_sky/AtmosphericSky.hpp"
 #include "skies/empty_sky/EmptySky.hpp"
@@ -23,19 +24,25 @@ void Raytracer::run()
         return;
 
     FrameBuffer frameBuffer;
-    PerspectiveCamera camera(Vector3D::zero(), Vector3D::zero(), 60, 16.0/9.0, 1920, 1080);
+    PerspectiveCamera camera(Vector3D(0, 1.5f, 0), Vector3D(-25, 0, 0), 60, 16.0/9.0, 1920, 1080);
     Image _image(camera.getWidth(), camera.getHeight());
-    std::shared_ptr<IMaterial> lambertian = std::make_shared<Lambertian>(Color(0.7, 0.3, 0.3));
-    
-    auto sky = std::make_unique<AtmosphericSky>(Color(0.5, 0.7, 1.0), Color(1.0, 1.0, 1.0));
+    std::shared_ptr<IMaterial> lambertianRed = std::make_shared<Lambertian>(Color(0.7, 0.3, 0.3));
+    std::shared_ptr<IMaterial> lambertianGreen = std::make_shared<Lambertian>(Color(0.3, 0.7, 0.3));
+    std::shared_ptr<IMaterial> transparent = std::make_shared<Transparent>(Color(0.8, 0.8, 0.8), 0.8);
+
+    auto sky = std::make_unique<AtmosphericSky>(Color(0.5, 0.7, 1.0), Color(0.5, 0.5, 0.5));
     auto emptySky = std::make_unique<EmptySky>();
     auto galaxySky = std::make_unique<GalaxySky>();
-    auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, -3), 0.5, lambertian);
-    auto sphere2 = std::make_shared<Sphere>(Vector3D(1.2, 0, -3), 0.5, lambertian);
+    auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, -3), 0.5, lambertianRed);
+    auto sphere2 = std::make_shared<Sphere>(Vector3D(1.2, 0, -3), 0.5, lambertianRed);
+    auto sphere3 = std::make_shared<Sphere>(Vector3D(-0.5, 0, -2), 0.5, transparent);
+    auto bigSphere = std::make_shared<Sphere>(Vector3D(0, -100.5, -1), 100, lambertianGreen);
     auto light = std::make_shared<PointLight>(Vector3D(1, 1.4, -2), Color(1, 1, 1), .5);
-    _scene.setSky(std::move(galaxySky));
+    _scene.setSky(std::move(sky));
     _scene.addPrimitive(sphere);
     _scene.addPrimitive(sphere2);
+    _scene.addPrimitive(sphere3);
+    _scene.addPrimitive(bigSphere);
     _scene.addLight(light);
     _scene.setBackgroundColor(Color(0, 0, 0));
 

--- a/src/core/camera/ACamera.hpp
+++ b/src/core/camera/ACamera.hpp
@@ -34,7 +34,7 @@ protected:
             -cos(pitch) * cos(yaw)
         ).normalized();
 
-        _setupBase(vup);
+        setupBase(vup);
 
         if (roll != 0) {
             Vector3D old_right = _right;
@@ -46,9 +46,9 @@ protected:
     }
 
 private:
-    void _setupBase(const Vector3D& vup) {
+    void setupBase(const Vector3D& vup) {
         if (std::abs(_forward.dot(vup)) > 0.999) {
-            _right = _forward.cross(Vector3D::unit_z()).normalized();
+            _right = _forward.cross(Vector3D::unitZ()).normalized();
         } else {
             _right = _forward.cross(vup).normalized();
         }

--- a/src/core/camera/PerspectiveCamera.cpp
+++ b/src/core/camera/PerspectiveCamera.cpp
@@ -8,7 +8,7 @@ namespace Raytracer
 PerspectiveCamera::PerspectiveCamera(const Point3D& origin, const Vector3D& rotation, double fov, double aspect_ratio, int width, int height)
     : ACamera(origin, rotation, Vector3D::up(), width, height)
 {
-    _initialize(fov, aspect_ratio);
+    initialize(fov, aspect_ratio);
 }
 
 Ray PerspectiveCamera::getRay(double u, double v) const
@@ -18,7 +18,7 @@ Ray PerspectiveCamera::getRay(double u, double v) const
     return Ray(_origin, target_point - _origin);
 }
 
-void PerspectiveCamera::_initialize(double fov, double aspect_ratio)
+void PerspectiveCamera::initialize(double fov, double aspect_ratio)
 {
     double theta = fov * M_PI / 180.0;
     double h = std::tan(theta / 2.0);

--- a/src/core/camera/PerspectiveCamera.hpp
+++ b/src/core/camera/PerspectiveCamera.hpp
@@ -17,7 +17,7 @@ private:
     Vector3D _vertical;
     Point3D _lower_left_corner;
 
-    void _initialize(double fov, double aspect_ratio);
+    void initialize(double fov, double aspect_ratio);
 };
 
 } // namespace Raytracer

--- a/src/core/image/Image.cpp
+++ b/src/core/image/Image.cpp
@@ -9,9 +9,9 @@ void Image::drawFromBuffer(const FrameBuffer& buffer, const std::string& filenam
     file << "P3\n" << _width << " " << _height << "\n255\n";
 
     for (const auto& color : buffer) {
-        int ir = Color::to_byte(color.r);
-        int ig = Color::to_byte(color.g);
-        int ib = Color::to_byte(color.b);
+        int ir = Color::toByte(color.r);
+        int ig = Color::toByte(color.g);
+        int ib = Color::toByte(color.b);
 
         file << ir << " " << ig << " " << ib << "\n";
     }

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -1,6 +1,7 @@
 #include "Renderer.hpp"
 #include "components/IMaterial.hpp"
 #include "math/Color.hpp"
+#include "math/MathUtils.hpp"
 
 namespace Raytracer
 {
@@ -14,14 +15,22 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
 
     for (int y = 0; y < height; ++y) {
         for (int x = 0; x < width; ++x) {
-            Color pixel_color;
+            Color pixel_color(0, 0, 0);
+            int sqrt_samples = std::sqrt(_samples);
 
-            double u = static_cast<double>(x) / (width - 1.0);
-            double v = 1.0 - static_cast<double>(y) / (height - 1.0);
+            for (int s_y = 0; s_y < sqrt_samples; ++s_y) {
+                for (int s_x = 0; s_x < sqrt_samples; ++s_x) {
+                    double u_offset = (s_x + Math::random_double(0, 1)) / sqrt_samples - anti_aliasing_interval;
+                    double v_offset = (s_y + Math::random_double(0, 1)) / sqrt_samples - anti_aliasing_interval;
 
-            Ray r = camera.getRay(u, v);
-            pixel_color += computeRayColor(r, scene, 50);
-            buffer[y * width + x] = pixel_color;
+                    double u = (static_cast<double>(x) + u_offset) / (width - 1.0);
+                    double v = 1.0 - (static_cast<double>(y) + v_offset) / (height - 1.0);
+
+                    Ray r = camera.getRay(u, v);
+                    pixel_color += computeRayColor(r, scene, 50);
+                }
+            }
+            buffer[y * width + x] = pixel_color / static_cast<double>(_samples);
         }
     }
 }
@@ -30,26 +39,24 @@ Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth, boo
     if (depth <= 0) return Color(0, 0, 0);
 
     HitRecord rec;
-    if (scene.getWorld().hit(r, Interval(0.001, std::numeric_limits<double>::max()), rec)) {
-        Ray scattered;
-        Color attenuation;
-
-        Color emitted = rec.material->emit(rec);
-
-        if (rec.material->scatter(r, rec, attenuation, scattered)) {
-            double specWeight = rec.material->getSpecularWeight();
-            double diffuseWeight = 1.0 - specWeight;
-
-            Color direct_light(0, 0, 0);
-            if (diffuseWeight > 0) {
-                direct_light = computeDirectLighting(rec, scene, attenuation) * diffuseWeight;
-            }
-            return emitted + direct_light + attenuation * computeRayColor(scattered, scene, depth - 1, false);
-        }
-        return emitted;
+    if (!scene.getWorld().hit(r, Interval(0.001, std::numeric_limits<double>::max()), rec)) {
+        return isFirstRay ? scene.getSky().getBackgroundColor(r) : scene.getSky().getEnvironmentColor(r);
     }
 
-    return isFirstRay ? scene.getSky().getBackgroundColor(r) : scene.getSky().getEnvironmentColor(r);
+    Color emission = (isFirstRay) ? rec.material->emit(rec) : Color(0,0,0);
+
+    Ray scattered;
+    Color attenuation;
+    if (rec.material->scatter(r, rec, attenuation, scattered)) {        
+        Color direct = computeDirectLighting(rec, scene, attenuation);
+
+        double diffuseWeight = 1.0 - rec.material->getSpecularWeight();
+        Color indirect = attenuation * computeRayColor(scattered, scene, depth - 1, false);
+
+        return emission + (direct * diffuseWeight) + indirect;
+    }
+
+    return emission;
 }
 
 Color Renderer::computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -1,5 +1,6 @@
 #include "Renderer.hpp"
 #include "components/IMaterial.hpp"
+#include "math/Color.hpp"
 
 namespace Raytracer
 {
@@ -29,40 +30,60 @@ Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth, boo
     if (depth <= 0) return Color(0, 0, 0);
 
     HitRecord rec;
-    if (scene.getWorld().hit(r, Interval(0.001, Interval::universe.max), rec)) {
+    if (scene.getWorld().hit(r, Interval(0.001, std::numeric_limits<double>::max()), rec)) {
         Ray scattered;
         Color attenuation;
 
+        Color emitted = rec.material->emit(rec);
+
         if (rec.material->scatter(r, rec, attenuation, scattered)) {
-            Color direct_light = computeDirectLighting(rec, scene, attenuation);
+            double specWeight = rec.material->getSpecularWeight();
+            double diffuseWeight = 1.0 - specWeight;
 
-            return direct_light + attenuation * computeRayColor(scattered, scene, depth - 1, false);
+            Color direct_light(0, 0, 0);
+            if (diffuseWeight > 0) {
+                direct_light = computeDirectLighting(rec, scene, attenuation) * diffuseWeight;
+            }
+            return emitted + direct_light + attenuation * computeRayColor(scattered, scene, depth - 1, false);
         }
-        return Color(0, 0, 0);
+        return emitted;
     }
 
-    if (!isFirstRay) {
-        return scene.getSky().getEnvironmentColor(r);
-    }
-    return scene.getSky().getBackgroundColor(r);
+    return isFirstRay ? scene.getSky().getBackgroundColor(r) : scene.getSky().getEnvironmentColor(r);
 }
 
 Color Renderer::computeDirectLighting(const HitRecord& rec, const Scene& scene, const Color& attenuation)
 {
-    Color direct_light(0, 0, 0);
+    Color total_direct_light(0, 0, 0);
+
     for (const auto& light : scene.getLights()) {
         LightSample sample = light->computeLight(rec.point);
         if (!sample.isActive) continue;
 
         Ray shadow_ray(rec.point + rec.normal * 0.001, sample.direction);
-        HitRecord shadow_rec;
+        Color light_visibility(1.0, 1.0, 1.0);
+        double t_min = 0.001;
 
-        if (!scene.getWorld().hit(shadow_ray, Interval(0.001, sample.distance), shadow_rec)) {
+        HitRecord shadow_rec;
+        while (scene.getWorld().hit(shadow_ray, Interval(t_min, sample.distance), shadow_rec)) {
+            Color transmittance = shadow_rec.material->getTransmittance();
+            
+            light_visibility *= transmittance;
+
+            if (light_visibility.isNearZero()) {
+                light_visibility = Color(0, 0, 0);
+                break;
+            }
+
+            t_min = shadow_rec.t + 0.001;
+        }
+
+        if (!light_visibility.isNearZero()) {
             double cos_theta = std::max(0.0, rec.normal.dot(sample.direction));
-            direct_light += (attenuation * sample.color) * cos_theta;
+            total_direct_light += (attenuation * sample.color * light_visibility) * cos_theta;
         }
     }
-    return direct_light;
+    return total_direct_light;
 }
 
 } // namespace Raytracer

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -20,8 +20,8 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
 
             for (int s_y = 0; s_y < sqrt_samples; ++s_y) {
                 for (int s_x = 0; s_x < sqrt_samples; ++s_x) {
-                    double u_offset = (s_x + Math::random_double(0, 1)) / sqrt_samples - anti_aliasing_interval;
-                    double v_offset = (s_y + Math::random_double(0, 1)) / sqrt_samples - anti_aliasing_interval;
+                    double u_offset = (s_x + Math::randomDouble(0, 1)) / sqrt_samples - anti_aliasing_interval;
+                    double v_offset = (s_y + Math::randomDouble(0, 1)) / sqrt_samples - anti_aliasing_interval;
 
                     double u = (static_cast<double>(x) + u_offset) / (width - 1.0);
                     double v = 1.0 - (static_cast<double>(y) + v_offset) / (height - 1.0);

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -19,6 +19,12 @@ public:
 
     void render(const ICamera& camera, const Scene& scene, FrameBuffer& buffer);
 
+    void setSamples(int samples) { _samples = samples; }
+    void setMaxDepth(int depth) { _maxDepth = depth; }
+
+private:
+    static constexpr float anti_aliasing_interval = 0.5f;
+
 private:
     int _samples;
     int _maxDepth;

--- a/src/lights/point_light/PointLight.cpp
+++ b/src/lights/point_light/PointLight.cpp
@@ -6,7 +6,7 @@ namespace Raytracer
 LightSample PointLight::computeLight(const Point3D& hit_point) const
 {
     Vector3D direction = (_position - hit_point);
-    double distance_squared = direction.length_squared();
+    double distance_squared = direction.lengthSquared();
     direction.normalize();
 
     LightSample sample;

--- a/src/materials/commun/AMaterial.hpp
+++ b/src/materials/commun/AMaterial.hpp
@@ -7,8 +7,12 @@ namespace Raytracer
 
 class AMaterial : public IMaterial
 {
-protected:
-    AMaterial() = default;
+public:
+    double getSpecularWeight() const override { return 0.0; }
+
+    Color getTransmittance() const override { return Color(0, 0, 0); }
+
+    Color emit(const HitRecord& rec) const override { return Color(0, 0, 0); }
 };
 
 } // namespace Raytracer

--- a/src/materials/commun/AMaterial.hpp
+++ b/src/materials/commun/AMaterial.hpp
@@ -12,7 +12,7 @@ public:
 
     Color getTransmittance() const override { return Color(0, 0, 0); }
 
-    Color emit(const HitRecord& rec) const override { return Color(0, 0, 0); }
+    Color emit([[maybe_unused]] const HitRecord& rec) const override { return Color(0, 0, 0); }
 };
 
 } // namespace Raytracer

--- a/src/materials/commun/AMaterial.hpp
+++ b/src/materials/commun/AMaterial.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "components/IMaterial.hpp"
+
+namespace Raytracer
+{
+
+class AMaterial : public IMaterial
+{
+protected:
+    AMaterial() = default;
+};
+
+} // namespace Raytracer

--- a/src/materials/lambertian/Lambertian.cpp
+++ b/src/materials/lambertian/Lambertian.cpp
@@ -14,7 +14,7 @@ bool Lambertian::scatter(
     Ray& scattered
 ) const
 {
-    auto scatter_direction = rec.normal + Vector3D::random_unit_vector();
+    auto scatter_direction = rec.normal + Vector3D::getRandomUnitVector();
 
     if (scatter_direction.isNearZero())
         scatter_direction = rec.normal;

--- a/src/materials/lambertian/Lambertian.cpp
+++ b/src/materials/lambertian/Lambertian.cpp
@@ -15,7 +15,7 @@ bool Lambertian::scatter(
 ) const
 {
     auto scatter_direction = rec.normal + Vector3D::random_unit_vector();
-    if (scatter_direction.near_zero())
+    if (scatter_direction.isNearZero())
         scatter_direction = rec.normal;
 
     scattered = Ray(rec.point, scatter_direction);

--- a/src/materials/lambertian/Lambertian.cpp
+++ b/src/materials/lambertian/Lambertian.cpp
@@ -15,10 +15,11 @@ bool Lambertian::scatter(
 ) const
 {
     auto scatter_direction = rec.normal + Vector3D::random_unit_vector();
+
     if (scatter_direction.isNearZero())
         scatter_direction = rec.normal;
 
-    scattered = Ray(rec.point, scatter_direction);
+    scattered = Ray(rec.point, scatter_direction.normalized());
     attenuation = _albedo;
     return true;
 }

--- a/src/materials/lambertian/Lambertian.hpp
+++ b/src/materials/lambertian/Lambertian.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "components/IMaterial.hpp"
+#include "materials/commun/AMaterial.hpp"
 
 namespace Raytracer
 {
 
-class Lambertian : public IMaterial
+class Lambertian : public AMaterial
 {
 public:
     Lambertian(const Color& albedo);

--- a/src/materials/transparent/CMakeLists.txt
+++ b/src/materials/transparent/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(raytracer_transparent SHARED
+    Transparent.cpp
+)
+
+target_include_directories(raytracer_transparent PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_transparent PRIVATE
+    -W
+    -Wall
+    -Wextra
+)
+
+set_target_properties(raytracer_transparent PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "raytracer_transparent"
+)

--- a/src/materials/transparent/Transparent.cpp
+++ b/src/materials/transparent/Transparent.cpp
@@ -1,0 +1,29 @@
+#include "Transparent.hpp"
+#include "math/MathUtils.hpp"
+
+namespace Raytracer
+{
+
+bool Transparent::scatter(const Ray& r_in, const HitRecord& rec, Color& attenuation, Ray& scattered) const
+{
+    attenuation = _albedo;
+    double ratio = rec.front_face ? (1.0 / _ref_idx) : _ref_idx;
+
+    Vector3D unit_direction = r_in.direction().normalized();
+    double cos_theta = std::min((-unit_direction).dot(rec.normal), 1.0);
+    double sin_theta = std::sqrt(1.0 - cos_theta * cos_theta);
+
+    bool cannot_refract = ratio * sin_theta > 1.0;
+    Vector3D direction;
+
+    if (cannot_refract || Math::reflectance(cos_theta, ratio) > Math::random_double(0.0, 1.0)) {
+        direction = Math::reflect(unit_direction, rec.normal);
+    } else {
+        direction = Math::refract(unit_direction, rec.normal, ratio);
+    }
+
+    scattered = Ray(rec.point, direction);
+    return true;
+}
+
+} // namespace Raytracer

--- a/src/materials/transparent/Transparent.cpp
+++ b/src/materials/transparent/Transparent.cpp
@@ -16,7 +16,7 @@ bool Transparent::scatter(const Ray& r_in, const HitRecord& rec, Color& attenuat
     bool cannot_refract = ratio * sin_theta > 1.0;
     Vector3D direction;
 
-    if (cannot_refract || Math::reflectance(cos_theta, ratio) > Math::random_double(0.0, 1.0)) {
+    if (cannot_refract || Math::reflectance(cos_theta, ratio) > Math::randomDouble(0.0, 1.0)) {
         direction = Math::reflect(unit_direction, rec.normal);
     } else {
         direction = Math::refract(unit_direction, rec.normal, ratio);

--- a/src/materials/transparent/Transparent.hpp
+++ b/src/materials/transparent/Transparent.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "materials/commun/AMaterial.hpp"
+
+namespace Raytracer
+{
+
+class Transparent : public AMaterial
+{
+public:
+    Transparent(Color albedo, double ref_idx): 
+        _albedo(albedo), _ref_idx(ref_idx) {}
+
+    bool scatter(
+        const Ray& r_in,
+        const HitRecord& rec,
+        Color& attenuation,
+        Ray& scattered
+    ) const override;
+    
+    double getSpecularWeight() const override { return 1.0; }
+    
+    Color getTransmittance() const override { return _albedo; }
+
+    virtual std::string getName() const override { return "transparent"; }
+
+private:
+    Color _albedo;
+    double _ref_idx;
+};
+
+} // namespace Raytracer

--- a/src/primitives/sphere/Sphere.cpp
+++ b/src/primitives/sphere/Sphere.cpp
@@ -67,7 +67,7 @@ bool Sphere::hit(const Ray& r, Interval ray_t, HitRecord& rec) const
     Vector3D normal = (rec.point - _center) / _radius;
     
     // check if ray hit inside or outside and oriente in function
-    rec.set_face_normal(r, normal);
+    rec.setFaceNormal(r, normal);
 
     rec.material = _material;
 

--- a/tests/materials/materials_tests.cpp
+++ b/tests/materials/materials_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "materials/lambertian/Lambertian.hpp"
+#include "materials/transparent/Transparent.hpp"
 #include "math/Ray.hpp"
 #include "math/HitRecord.hpp"
 #include "math/Vector3D.hpp"
@@ -93,4 +94,43 @@ TEST(Lambertian, GetName)
     Raytracer::Lambertian material({0.8, 0.8, 0.8});
 
     EXPECT_EQ(material.getName(), "lambertian");
+}
+
+// Transparent tests
+TEST(Transparent, BasicProperties)
+{
+    Raytracer::Transparent material({0.9, 0.8, 0.7}, 1.5);
+
+    EXPECT_EQ(material.getName(), "transparent");
+    EXPECT_DOUBLE_EQ(material.getSpecularWeight(), 1.0);
+
+    Raytracer::Color transmittance = material.getTransmittance();
+    EXPECT_DOUBLE_EQ(transmittance.r, 0.9);
+    EXPECT_DOUBLE_EQ(transmittance.g, 0.8);
+    EXPECT_DOUBLE_EQ(transmittance.b, 0.7);
+}
+
+TEST(Transparent, ScatterUsesReflectionWhenCannotRefract)
+{
+    Raytracer::Transparent material({0.7, 0.8, 0.9}, 1.5);
+
+    Raytracer::Ray ray_in({0.0, 0.0, 0.0}, {0.8, 0.0, -0.6});
+    Raytracer::HitRecord rec;
+    rec.point = {1.0, 2.0, 3.0};
+    rec.normal = {0.0, 0.0, 1.0};
+    rec.front_face = false;
+
+    Raytracer::Color attenuation;
+    Raytracer::Ray scattered;
+
+    bool result = material.scatter(ray_in, rec, attenuation, scattered);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(attenuation.r, 0.7);
+    EXPECT_DOUBLE_EQ(attenuation.g, 0.8);
+    EXPECT_DOUBLE_EQ(attenuation.b, 0.9);
+    expectVectorNear(scattered.origin(), rec.point);
+
+    Raytracer::Vector3D expected = {0.8, 0.0, 0.6};
+    expectVectorNear(scattered.direction(), expected);
 }

--- a/tests/math/math_tests.cpp
+++ b/tests/math/math_tests.cpp
@@ -35,9 +35,9 @@ TEST(Vector3D, BasicArithmetic)
 
 TEST(Vector3D, DotCrossAndNormalize)
 {
-    const Raytracer::Vector3D x = Raytracer::Vector3D::unit_x();
-    const Raytracer::Vector3D y = Raytracer::Vector3D::unit_y();
-    const Raytracer::Vector3D z = Raytracer::Vector3D::unit_z();
+    const Raytracer::Vector3D x = Raytracer::Vector3D::unitX();
+    const Raytracer::Vector3D y = Raytracer::Vector3D::unitY();
+    const Raytracer::Vector3D z = Raytracer::Vector3D::unitZ();
 
     EXPECT_DOUBLE_EQ(x.dot(y), 0.0);
     expectVectorNear(x.cross(y), z);
@@ -86,9 +86,9 @@ TEST(Interval, ContainsAndClamp)
 
 TEST(Color, ToByte)
 {
-    EXPECT_EQ(Raytracer::Color::to_byte(0.0), 0);
-    EXPECT_EQ(Raytracer::Color::to_byte(0.25), 128);
-    EXPECT_EQ(Raytracer::Color::to_byte(1.0), 255);
+    EXPECT_EQ(Raytracer::Color::toByte(0.0), 0);
+    EXPECT_EQ(Raytracer::Color::toByte(0.25), 128);
+    EXPECT_EQ(Raytracer::Color::toByte(1.0), 255);
 }
 
 TEST(MathUtils, DegreesAndRadians)
@@ -178,7 +178,7 @@ TEST(Vector3D, RandomVector)
 // Vector3D random unit vector
 TEST(Vector3D, RandomUnitVector)
 {
-    Raytracer::Vector3D v = Raytracer::Vector3D::random_unit_vector();
+    Raytracer::Vector3D v = Raytracer::Vector3D::getRandomUnitVector();
     
     // Length should be approximately 1
     EXPECT_NEAR(v.length(), 1.0, 1e-6);

--- a/tests/math/math_tests.cpp
+++ b/tests/math/math_tests.cpp
@@ -61,8 +61,8 @@ TEST(Vector3D, NearZero)
     const Raytracer::Vector3D small{1e-10, -1e-11, 9e-10};
     const Raytracer::Vector3D large{1e-4, 0.0, 0.0};
 
-    EXPECT_TRUE(small.near_zero());
-    EXPECT_FALSE(large.near_zero());
+    EXPECT_TRUE(small.isNearZero());
+    EXPECT_FALSE(large.isNearZero());
 }
 
 TEST(Ray, At)

--- a/tests/scene/scene_tests.cpp
+++ b/tests/scene/scene_tests.cpp
@@ -40,7 +40,7 @@ class FakeLight : public Raytracer::ILight
 public:
     Raytracer::LightSample computeLight(const Raytracer::Point3D&) const override
     {
-        return {{1.0, 1.0, 1.0}, Raytracer::Vector3D::unit_z(), 1.0, true};
+        return {{1.0, 1.0, 1.0}, Raytracer::Vector3D::unitZ(), 1.0, true};
     }
 };
 


### PR DESCRIPTION
## FIXES

Issue #55 

## Description

Add antialiasing to the renderer loop

### How
- When process a ray, create n ray around it with random value and take the average color

### Testing
1. **Execution**: ./raytracer
2. **Validation**: less noisy image

### Notes
- **Next**: Add optimisation
- **Technical Details**: The image take n time longer to generate
- **Refactoring**: a function for the antialiasing
