### PR TITLE
[MATH] Matrix Class Implementation (#9)

### DIFF
--- a/include/math/Matrix.hpp
+++ b/include/math/Matrix.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "math/Vector3D.hpp"
+
+namespace Raytracer {
+
+/**
+ * @brief 4x4 Matrix class used for 3D transformations.
+ */
+class Matrix {
+public:
+    double m[4][4];
+
+    /**
+     * @brief Construct a new Matrix object natively initialized to Identity Matrix.
+     */
+    Matrix() noexcept;
+
+    /**
+     * @brief Matrix-Matrix multiplication.
+     */
+    Matrix operator*(const Matrix& other) const noexcept;
+
+    /**
+     * @brief Matrix-Vector multiplication (Transformation).
+     */
+    Vector3D operator*(const Vector3D& vec) const noexcept;
+
+    /**
+     * @brief Generate a rotation matrix around the X-axis.
+     * @param angle_radians Angle in radians.
+     */
+    static Matrix rotateX(double angle_radians) noexcept;
+
+    /**
+     * @brief Generate a rotation matrix around the Y-axis.
+     * @param angle_radians Angle in radians.
+     */
+    static Matrix rotateY(double angle_radians) noexcept;
+
+    /**
+     * @brief Generate a rotation matrix around the Z-axis.
+     * @param angle_radians Angle in radians.
+     */
+    static Matrix rotateZ(double angle_radians) noexcept;
+
+    /**
+     * @brief Generates a transformation utility (LookAt).
+     * Transforms from world space to camera view space.
+     */
+    static Matrix
+    lookAt(const Point3D& position, const Point3D& target, const Vector3D& up) noexcept;
+};
+
+} // namespace Raytracer

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(materials)
 add_subdirectory(lights)
 add_subdirectory(primitives)
 add_subdirectory(skies)
+add_subdirectory(math)
 
 add_executable(raytracer main.cpp)
 
@@ -19,4 +20,5 @@ target_compile_options(raytracer PRIVATE
 
 target_link_libraries(raytracer PRIVATE
     raytracer_core
+    raytracer_math
 )

--- a/src/core/camera/ACamera.hpp
+++ b/src/core/camera/ACamera.hpp
@@ -2,6 +2,7 @@
 
 #include "components/ICamera.hpp"
 #include "math/MathUtils.hpp"
+#include "math/Matrix.hpp"
 #include "math/Vector3D.hpp"
 
 namespace Raytracer {
@@ -41,12 +42,11 @@ protected:
 
 private:
     void setupBase(const Vector3D& vup) {
-        if (std::abs(_forward.dot(vup)) > 0.999) {
-            _right = _forward.cross(Vector3D::unitZ()).normalized();
-        } else {
-            _right = _forward.cross(vup).normalized();
-        }
-        _up = _right.cross(_forward);
+        const Matrix basis = Matrix::lookAt(_origin, _origin + _forward, vup);
+
+        _right = {basis.m[0][0], basis.m[0][1], basis.m[0][2]};
+        _up = {basis.m[1][0], basis.m[1][1], basis.m[1][2]};
+        _forward = {-basis.m[2][0], -basis.m[2][1], -basis.m[2][2]};
     }
 };
 

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(raytracer_math STATIC
+    Matrix.cpp
+)
+
+target_include_directories(raytracer_math PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_math PRIVATE
+    -W
+    -Wall
+    -Wextra
+)

--- a/src/math/Matrix.cpp
+++ b/src/math/Matrix.cpp
@@ -1,0 +1,102 @@
+#include "math/Matrix.hpp"
+
+#include <cmath>
+
+namespace Raytracer {
+
+Matrix::Matrix() noexcept {
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            m[i][j] = (i == j) ? 1.0 : 0.0;
+        }
+    }
+}
+
+Matrix Matrix::operator*(const Matrix& other) const noexcept {
+    Matrix result;
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            result.m[i][j] = 0;
+            for (int k = 0; k < 4; ++k) {
+                result.m[i][j] += m[i][k] * other.m[k][j];
+            }
+        }
+    }
+    return result;
+}
+
+Vector3D Matrix::operator*(const Vector3D& vec) const noexcept {
+    double x = m[0][0] * vec.x + m[0][1] * vec.y + m[0][2] * vec.z + m[0][3] * 1.0;
+    double y = m[1][0] * vec.x + m[1][1] * vec.y + m[1][2] * vec.z + m[1][3] * 1.0;
+    double z = m[2][0] * vec.x + m[2][1] * vec.y + m[2][2] * vec.z + m[2][3] * 1.0;
+    double w = m[3][0] * vec.x + m[3][1] * vec.y + m[3][2] * vec.z + m[3][3] * 1.0;
+
+    if (w != 0.0 && w != 1.0) {
+        return Vector3D(x / w, y / w, z / w);
+    }
+    return Vector3D(x, y, z);
+}
+
+Matrix Matrix::rotateX(double angle_radians) noexcept {
+    Matrix result;
+    double c = std::cos(angle_radians);
+    double s = std::sin(angle_radians);
+    result.m[1][1] = c;
+    result.m[1][2] = -s;
+    result.m[2][1] = s;
+    result.m[2][2] = c;
+    return result;
+}
+
+Matrix Matrix::rotateY(double angle_radians) noexcept {
+    Matrix result;
+    double c = std::cos(angle_radians);
+    double s = std::sin(angle_radians);
+    result.m[0][0] = c;
+    result.m[0][2] = s;
+    result.m[2][0] = -s;
+    result.m[2][2] = c;
+    return result;
+}
+
+Matrix Matrix::rotateZ(double angle_radians) noexcept {
+    Matrix result;
+    double c = std::cos(angle_radians);
+    double s = std::sin(angle_radians);
+    result.m[0][0] = c;
+    result.m[0][1] = -s;
+    result.m[1][0] = s;
+    result.m[1][1] = c;
+    return result;
+}
+
+Matrix Matrix::lookAt(const Point3D& position, const Point3D& target, const Vector3D& up) noexcept {
+    Vector3D forward = (position - target).normalized(); // z-axis
+    Vector3D right = up.cross(forward).normalized();     // x-axis
+    Vector3D new_up = forward.cross(right);              // y-axis
+
+    Matrix result;
+    result.m[0][0] = right.x;
+    result.m[0][1] = right.y;
+    result.m[0][2] = right.z;
+    result.m[0][3] = -right.dot(position);
+
+    result.m[1][0] = new_up.x;
+    result.m[1][1] = new_up.y;
+    result.m[1][2] = new_up.z;
+    result.m[1][3] = -new_up.dot(position);
+
+    result.m[2][0] = forward.x;
+    result.m[2][1] = forward.y;
+    result.m[2][2] = forward.z;
+    result.m[2][3] = -forward.dot(position);
+
+    result.m[3][0] = 0.0;
+    result.m[3][1] = 0.0;
+    result.m[3][2] = 0.0;
+    result.m[3][3] = 1.0;
+
+    return result;
+}
+
+} // namespace Raytracer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ target_include_directories(raytracer_unit_tests PRIVATE
 
 target_link_libraries(raytracer_unit_tests PRIVATE
     raytracer_core
+    raytracer_math
     GTest::gtest_main
 )
 

--- a/tests/math/math_tests.cpp
+++ b/tests/math/math_tests.cpp
@@ -5,6 +5,7 @@
 #include "math/Color.hpp"
 #include "math/Interval.hpp"
 #include "math/MathUtils.hpp"
+#include "math/Matrix.hpp"
 #include "math/Ray.hpp"
 #include "math/Vector3D.hpp"
 
@@ -16,6 +17,16 @@ void expectVectorNear(const Raytracer::Vector3D& actual,
     EXPECT_NEAR(actual.x, expected.x, epsilon);
     EXPECT_NEAR(actual.y, expected.y, epsilon);
     EXPECT_NEAR(actual.z, expected.z, epsilon);
+}
+
+void expectMatrixNear(const Raytracer::Matrix& actual,
+                      const Raytracer::Matrix& expected,
+                      double epsilon = 1e-12) {
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            EXPECT_NEAR(actual.m[i][j], expected.m[i][j], epsilon);
+        }
+    }
 }
 
 } // namespace
@@ -87,6 +98,69 @@ TEST(MathUtils, DegreesAndRadians) {
 
     EXPECT_NEAR(Raytracer::Math::degreesToRadians(180.0), pi, 1e-12);
     EXPECT_NEAR(Raytracer::Math::radiansToDegrees(pi), 180.0, 1e-12);
+}
+
+TEST(Matrix, DefaultConstructorBuildsIdentity) {
+    const Raytracer::Matrix matrix;
+    const Raytracer::Matrix identity;
+
+    expectMatrixNear(matrix, identity);
+}
+
+TEST(Matrix, RotationX) {
+    const double pi = std::acos(-1.0);
+    const Raytracer::Matrix rotation = Raytracer::Matrix::rotateX(pi / 2.0);
+
+    expectVectorNear(rotation * Raytracer::Vector3D{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0});
+}
+
+TEST(Matrix, RotationY) {
+    const double pi = std::acos(-1.0);
+    const Raytracer::Matrix rotation = Raytracer::Matrix::rotateY(pi / 2.0);
+
+    expectVectorNear(rotation * Raytracer::Vector3D{0.0, 0.0, 1.0}, {1.0, 0.0, 0.0});
+}
+
+TEST(Matrix, RotationZ) {
+    const double pi = std::acos(-1.0);
+    const Raytracer::Matrix rotation = Raytracer::Matrix::rotateZ(pi / 2.0);
+
+    expectVectorNear(rotation * Raytracer::Vector3D{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0});
+}
+
+TEST(Matrix, MatrixMultiplicationComposesTransforms) {
+    const double pi = std::acos(-1.0);
+    const Raytracer::Matrix rotate_x = Raytracer::Matrix::rotateX(pi / 2.0);
+    const Raytracer::Matrix rotate_y = Raytracer::Matrix::rotateY(pi / 2.0);
+    const Raytracer::Matrix composed = rotate_y * rotate_x;
+    const Raytracer::Vector3D input{0.0, 1.0, 0.0};
+
+    expectVectorNear(composed * input, rotate_y * (rotate_x * input));
+}
+
+TEST(Matrix, LookAtBuildsExpectedBasis) {
+    const Raytracer::Matrix view =
+        Raytracer::Matrix::lookAt({0.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, 1.0, 0.0});
+
+    Raytracer::Matrix expected;
+    expected.m[0][0] = 1.0;
+    expected.m[0][1] = 0.0;
+    expected.m[0][2] = 0.0;
+    expected.m[0][3] = 0.0;
+    expected.m[1][0] = 0.0;
+    expected.m[1][1] = 1.0;
+    expected.m[1][2] = 0.0;
+    expected.m[1][3] = 0.0;
+    expected.m[2][0] = 0.0;
+    expected.m[2][1] = 0.0;
+    expected.m[2][2] = 1.0;
+    expected.m[2][3] = 0.0;
+    expected.m[3][0] = 0.0;
+    expected.m[3][1] = 0.0;
+    expected.m[3][2] = 0.0;
+    expected.m[3][3] = 1.0;
+
+    expectMatrixNear(view, expected);
 }
 
 // Vector3D augmented assignment operators


### PR DESCRIPTION
## FIXES

Issue #9

## Description

Implémentation de la classe Matrix 4x4 pour les transformations 3D, avec intégration de l’orientation caméra via Matrix::lookAt.

### How
- Ajout de la classe Matrix en séparation déclaration/implémentation (`include/math/Matrix.hpp`, `src/math/Matrix.cpp`).
- Implémentation des rotations `rotateX`, `rotateY`, `rotateZ`.
- Implémentation de la multiplication matrice-matrice et matrice-vecteur.
- Implémentation de `lookAt` pour la construction d’une base caméra.
- Intégration build: ajout de `src/math/CMakeLists.txt` et liaison dans `src/CMakeLists.txt` et `tests/CMakeLists.txt`.
- Intégration caméra: `ACamera` utilise désormais `Matrix::lookAt` pour construire `right/up/forward`.
- Ajout des tests unitaires Matrix dans `tests/math/math_tests.cpp`.

### Testing
1. **Execution**: `cmake -S . -B build && cmake --build build --target raytracer_unit_tests -j2 && ctest --test-dir build --output-on-failure`
2. **Validation**: 55/55 tests pass.

### Notes
- **Next**: N/A
- **Technical Details**: la base caméra est dérivée via la matrice de vue (`lookAt`) puis re-projetée sur les vecteurs de la caméra.
- **Refactoring**: séparation cohérente `.hpp`/`.cpp` pour rester aligné avec l’architecture du projet.