### PR TITLE
feat(renderer): implement adaptive sampling with threshold configuration

### DIFF
--- a/scenes/cult_of_the_spheres.scene
+++ b/scenes/cult_of_the_spheres.scene
@@ -60,5 +60,6 @@ sky = {
 };
 
 render = {
-    samples = 16;
+    samples = 100;
+    adaptive_threshold = 0.05;
 }

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -63,7 +63,9 @@ void Raytracer::run() {
     try {
         FrameBuffer frameBuffer;
         int samples = _parser.getRenderSamples();
+        double threshold = _parser.getRenderThreshold();
         _renderer.setSamples(samples);
+        _renderer.setAdaptiveThreshold(threshold);
         auto& camera = _scene.getCamera();
 
         auto renderTask = std::async(std::launch::async,

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -107,6 +107,20 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
     } catch (const libconfig::SettingNotFoundException&) {
         throw RenderSettingsException("render.samples is missing");
     }
+
+    if (renderSetting.exists("adaptive_threshold")) {
+        try {
+            _renderThreshold = static_cast<double>(renderSetting["adaptive_threshold"]);
+            if (_renderThreshold < 0.0 || _renderThreshold > 1.0) {
+                std::cerr << "Warning: render.adaptive_threshold must be between 0.0 and 1.0, "
+                          << "using default 0.1" << std::endl;
+                _renderThreshold = 0.1;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            std::cerr << "Warning: render.adaptive_threshold has invalid type (expected float)"
+                      << std::endl;
+        }
+    }
 }
 
 void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {

--- a/src/core/parser/SceneParser.hpp
+++ b/src/core/parser/SceneParser.hpp
@@ -16,6 +16,7 @@ public:
     explicit SceneParser(SceneFactories& factories) : _factories(factories) {}
 
     int getRenderSamples() const { return _renderSamples; }
+    double getRenderThreshold() const { return _renderThreshold; }
 
     /**
      * @param filePath Chemin vers le fichier .cfg à charger
@@ -66,6 +67,7 @@ private:
     SceneFactories& _factories;
     std::vector<void*> _pluginHandles;
     int _renderSamples = 16;
+    double _renderThreshold = 0.1;
 
     using SectionParser = void (SceneParser::*)(const libconfig::Setting&, Scene&);
     using SectionTable = std::unordered_map<std::string, SectionParser>;

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -31,25 +31,56 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
 
 Color Renderer::samplePixel(
     int x, int y, int width, int height, const ICamera& camera, const Scene& scene) {
-    Color pixel_color(0, 0, 0);
-    int sqrt_samples = static_cast<int>(std::sqrt(_samples));
 
-    for (int s_y = 0; s_y < sqrt_samples; ++s_y) {
-        for (int s_x = 0; s_x < sqrt_samples; ++s_x) {
-            double u_offset =
-                (s_x + Math::randomDouble(0, 1)) / sqrt_samples - anti_aliasing_interval;
-            double v_offset =
-                (s_y + Math::randomDouble(0, 1)) / sqrt_samples - anti_aliasing_interval;
-
-            double u = (static_cast<double>(x) + u_offset) / (width - 1.0);
-            double v = 1.0 - (static_cast<double>(y) + v_offset) / (height - 1.0);
-
-            Ray r = camera.getRay(u, v);
-            pixel_color += computeRayColor(r, scene, _maxDepth);
-        }
+    if (_samples < minimum_sampling) {
+        return renderFullBatch(x, y, width, height, camera, scene, _samples);
     }
 
-    return pixel_color / static_cast<double>(_samples);
+    double min_lum = 1e10, max_lum = -1e10;
+    Color initial_color(0, 0, 0);
+
+    for (int i = 0; i < initial_samples; ++i) {
+        Color c = traceSingleRay(x, y, width, height, camera, scene);
+        initial_color += c;
+
+        double lum = 0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b;
+        if (lum < min_lum)
+            min_lum = lum;
+        if (lum > max_lum)
+            max_lum = lum;
+    }
+
+    double diff = max_lum - min_lum;
+
+    if (diff < _adaptiveThreshold) {
+        return initial_color / static_cast<double>(initial_samples);
+    }
+
+    Color remaining_color =
+        renderFullBatch(x, y, width, height, camera, scene, _samples - initial_samples);
+
+    return (initial_color + remaining_color) / static_cast<double>(_samples);
+}
+
+Color Renderer::traceSingleRay(
+    int x, int y, int width, int height, const ICamera& camera, const Scene& scene) {
+    double u_offset = Math::randomDouble(-anti_aliasing_interval, anti_aliasing_interval);
+    double v_offset = Math::randomDouble(-anti_aliasing_interval, anti_aliasing_interval);
+
+    double u = (static_cast<double>(x) + u_offset) / (width - 1.0);
+    double v = 1.0 - (static_cast<double>(y) + v_offset) / (height - 1.0);
+
+    Ray r = camera.getRay(u, v);
+    return computeRayColor(r, scene, _maxDepth);
+}
+
+Color Renderer::renderFullBatch(
+    int x, int y, int width, int height, const ICamera& camera, const Scene& scene, int count) {
+    Color sum(0, 0, 0);
+    for (int i = 0; i < count; ++i) {
+        sum += traceSingleRay(x, y, width, height, camera, scene);
+    }
+    return sum;
 }
 
 Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -6,9 +6,9 @@
 #include "core/scene/Scene.hpp"
 #include "math/Color.hpp"
 #include "render/FrameBuffer.hpp"
+#include <atomic>
 #include <memory>
 #include <vector>
-#include <atomic>
 
 namespace Raytracer {
 
@@ -21,6 +21,7 @@ public:
 
     void setSamples(int samples) { _samples = samples; }
     void setMaxDepth(int depth) { _maxDepth = depth; }
+    void setAdaptiveThreshold(double threshold) { _adaptiveThreshold = threshold; }
 
     int getCompletedRows() const { return _completed_rows.load(); }
     int getTotalRows() const { return _total_rows; }
@@ -28,10 +29,13 @@ public:
 
 private:
     static constexpr float anti_aliasing_interval = 0.5f;
+    static constexpr int initial_samples = 4;
+    static constexpr int minimum_sampling = 8;
 
 private:
     int _samples;
     int _maxDepth;
+    double _adaptiveThreshold = 0.1;
 
     std::atomic<int> _completed_rows{0};
     std::atomic<bool> _is_rendering{false};
@@ -39,12 +43,18 @@ private:
 
 private:
     Color computeRayColor(const Ray& r, const Scene& scene, int depth);
-    Color
-    samplePixel(int x, int y, int width, int height, const ICamera& camera, const Scene& scene);
+
     Color computeDirectLighting(const Ray& r_in,
                                 const HitRecord& rec,
                                 const Scene& scene,
                                 const IBSDF& bsdf);
+
+    Color
+    samplePixel(int x, int y, int width, int height, const ICamera& camera, const Scene& scene);
+    Color renderFullBatch(
+        int x, int y, int width, int height, const ICamera& camera, const Scene& scene, int count);
+    Color
+    traceSingleRay(int x, int y, int width, int height, const ICamera& camera, const Scene& scene);
 };
 
 } // namespace Raytracer

--- a/src/materials/commun/CMakeLists.txt
+++ b/src/materials/commun/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(raytracer_materials_common STATIC
     bsdf/emissive/EmissiveBSDF.cpp
 )
 
-find_package(SFML COMPONENTS graphics system REQUIRED)
+find_package(SFML COMPONENTS Graphics System REQUIRED)
 target_link_libraries(raytracer_materials_common PUBLIC sfml-graphics sfml-system)
 
 set_target_properties(raytracer_materials_common PROPERTIES


### PR DESCRIPTION
## FIXES

Issue #84 

## Description

Add adaptive super sampling to the main renderer loop to use the anti aliasing depending on a bitmask map

### How
- Calculate with the help off a small sampling of 4 the threshold of the ray
- Depending of the value, use all the rest of the samples or not

### Testing
1. **Execution**: ./raytracer <scene> (with scene that got a high samples value)
2. **Validation**: render fast

### Notes
- **Next**: None
- **Technical Details**: Can have noisy image even with high samples 
- **Refactoring**: Enhence the parsing of the render part
