### PR TITLE
feat(renderer): implement ambient occlusion in ray color computation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libconfig++-dev libtbb-dev libsfml-dev
+          sudo apt-get install -y pkg-config libconfig++-dev libsfml-dev
 
       - name: Configure and Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ file(MAKE_DIRECTORY ${PLUGIN_DIR}/cameras)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBCONFIGPP REQUIRED libconfig++)
-find_package(TBB REQUIRED)
 
 add_subdirectory(src)
 

--- a/include/components/Entity.hpp
+++ b/include/components/Entity.hpp
@@ -103,12 +103,24 @@ public:
      * @return true if a valid hit exists in the interval.
      */
     bool hit(const Ray& r, Interval ray_t, HitRecord& rec) const override {
-        Ray local_ray(_transform_inv * r.origin(),
-                      _transform_inv.transformDirection(r.direction()));
+        // Transform ray to local space
+        Point3D local_origin = _transform_inv * r.origin();
+        Vector3D local_direction = _transform_inv.transformDirection(r.direction());
+        
+        // Create local ray with normalized direction for consistent distance calculations
+        Vector3D local_dir_normalized = local_direction.normalized();
+        double dir_scale = local_direction.length();
+        
+        // Adjust interval for scaled direction
+        Interval local_interval(ray_t.min / dir_scale, ray_t.max / dir_scale);
+        Ray local_ray(local_origin, local_dir_normalized);
 
-        if (!_primitive->hit(local_ray, ray_t, rec)) {
+        if (!_primitive->hit(local_ray, local_interval, rec)) {
             return false;
         }
+        
+        // Scale rec.t back to world space
+        rec.t *= dir_scale;
 
         rec.point = _transform * rec.point;
 
@@ -117,12 +129,6 @@ public:
         rec.front_face = r.direction().dot(rec.normal) < 0;
         if (!rec.front_face) {
             rec.normal = -rec.normal;
-        }
-
-        const Vector3D world_delta = rec.point - r.origin();
-        const double dir_len = r.direction().dot(r.direction());
-        if (dir_len > 0.0) {
-            rec.t = world_delta.dot(r.direction()) / dir_len;
         }
 
         rec.material = _material;

--- a/include/math/Ray.hpp
+++ b/include/math/Ray.hpp
@@ -12,7 +12,8 @@ enum class RayType {
     CAMERA,    /**< Primary ray from the camera. */
     REFLECT,   /**< Specular ray (sharp reflections/refractions). */
     DIFFUSE,   /**< Indirect ray (diffuse bounce for global illumination). */
-    SHADOW     /**< Ray used for visibility testing towards light sources. */
+    SHADOW,    /**< Ray used for visibility testing towards light sources. */
+    AMBIENT_OCCLUSION     /**< Ray used for ambient occlusion testing. */
 };
 
 /**

--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -168,6 +168,53 @@ struct Vector3D {
             }
         }
     }
+
+    /**
+     * @brief Return a random vector uniformly distributed in the unit sphere.
+     */
+    static Vector3D randomInUnitSphere() {
+        while (true) {
+            Vector3D p(getRandomDouble(-1, 1), getRandomDouble(-1, 1), getRandomDouble(-1, 1));
+            if (p.lengthSquared() >= 1)
+                continue;
+            return p;
+        }
+    }
+
+    /**
+     * @brief Return a random vector uniformly distributed in the hemisphere defined by the normal.
+     */
+    static Vector3D randomInHemisphere(const Vector3D& normal) {
+        Vector3D in_unit_sphere = randomInUnitSphere();
+        if (in_unit_sphere.dot(normal) > 0.0) {
+            return in_unit_sphere;
+        } else {
+            return -in_unit_sphere;
+        }
+    }
+
+    /**
+     * @brief Return a random vector cosine-weighted in the hemisphere defined by the normal.
+     */
+    static Vector3D randomCosineHemisphere(const Vector3D& normal) {
+        double r1 = getRandomDouble(0.0, 1.0);
+        double r2 = getRandomDouble(0.0, 1.0);
+        double phi = 2.0 * M_PI * r1;
+        double x = std::cos(phi) * std::sqrt(r2);
+        double y = std::sin(phi) * std::sqrt(r2);
+        double z = std::sqrt(std::max(0.0, 1.0 - r2));
+
+        Vector3D w = normal.normalized();
+        Vector3D a = (std::fabs(w.x) > 0.9) ? Vector3D(0, 1, 0) : Vector3D(1, 0, 0);
+        Vector3D v = w.cross(a).normalized();
+        Vector3D u = v.cross(w);
+
+        Vector3D res;
+        res.x = u.x * x + v.x * y + w.x * z;
+        res.y = u.y * x + v.y * y + w.y * z;
+        res.z = u.z * x + v.z * y + w.z * z;
+        return res.normalized();
+    }
 };
 
 [[nodiscard]] constexpr inline Vector3D operator+(const Vector3D& u, const Vector3D& v) noexcept {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -18,7 +18,6 @@ target_include_directories(raytracer_core PUBLIC
 )
 
 target_link_libraries(raytracer_core PUBLIC ${LIBCONFIGPP_LIBRARIES})
-target_link_libraries(raytracer_core PUBLIC TBB::tbb)
 
 target_compile_options(raytracer_core PRIVATE
     -W

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -66,6 +66,8 @@ void Raytracer::run() {
         double threshold = _parser.getRenderThreshold();
         _renderer.setSamples(samples);
         _renderer.setAdaptiveThreshold(threshold);
+        _renderer.setAmbientOcclusionSamples(_parser.getAOSamples());
+        _renderer.setAmbientOcclusionMaxDistance(_parser.getAOMaxDistance());
         auto& camera = _scene.getCamera();
 
         auto renderTask = std::async(std::launch::async,

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -121,6 +121,36 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                       << std::endl;
         }
     }
+
+    if (renderSetting.exists("ao_samples")) {
+        try {
+            const int a = static_cast<int>(renderSetting["ao_samples"]);
+            if (a < 0) {
+                std::cerr << "Warning: render.ao_samples must be >= 0, using default " << _aoSamples
+                          << std::endl;
+            } else {
+                _aoSamples = a;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            std::cerr << "Warning: render.ao_samples has invalid type (expected integer)"
+                      << std::endl;
+        }
+    }
+
+    if (renderSetting.exists("ao_max_distance")) {
+        try {
+            double d = static_cast<double>(renderSetting["ao_max_distance"]);
+            if (d <= 0.0) {
+                std::cerr << "Warning: render.ao_max_distance must be > 0, using default "
+                          << _aoMaxDistance << std::endl;
+            } else {
+                _aoMaxDistance = d;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            std::cerr << "Warning: render.ao_max_distance has invalid type (expected float)"
+                      << std::endl;
+        }
+    }
 }
 
 void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {

--- a/src/core/parser/SceneParser.hpp
+++ b/src/core/parser/SceneParser.hpp
@@ -17,6 +17,8 @@ public:
 
     int getRenderSamples() const { return _renderSamples; }
     double getRenderThreshold() const { return _renderThreshold; }
+    int getAOSamples() const { return _aoSamples; }
+    double getAOMaxDistance() const { return _aoMaxDistance; }
 
     /**
      * @param filePath Chemin vers le fichier .cfg à charger
@@ -68,6 +70,8 @@ private:
     std::vector<void*> _pluginHandles;
     int _renderSamples = 16;
     double _renderThreshold = 0.1;
+    int _aoSamples = 0;
+    double _aoMaxDistance = 10.0;
 
     using SectionParser = void (SceneParser::*)(const libconfig::Setting&, Scene&);
     using SectionTable = std::unordered_map<std::string, SectionParser>;

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -2,9 +2,9 @@
 #include "components/IMaterial.hpp"
 #include "math/Color.hpp"
 #include "math/MathUtils.hpp"
+#include "math/Vector3D.hpp"
 
-#include <execution>
-#include <numeric>
+#include <thread>
 
 namespace Raytracer {
 
@@ -18,15 +18,29 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
 
     buffer.assign(width * height, Color(0, 0, 0));
 
-    std::vector<int> rows(height);
-    std::iota(rows.begin(), rows.end(), 0);
+    unsigned int num_threads = std::thread::hardware_concurrency();
+    if (num_threads == 0) num_threads = 4;
 
-    std::for_each(std::execution::par, rows.begin(), rows.end(), [&](int y) {
-        for (int x = 0; x < width; ++x) {
-            buffer[y * width + x] = samplePixel(x, y, width, height, camera, scene);
-        }
-        _completed_rows++;
-    });
+    std::vector<std::jthread> workers;
+
+    int rows_per_thread = height / num_threads;
+
+    for (unsigned int t = 0; t < num_threads; ++t) {
+        int start_y = t * rows_per_thread;
+        int end_y = (t == num_threads - 1) ? height : start_y + rows_per_thread;
+
+        workers.emplace_back([this, start_y, end_y, width, height, &camera, &scene, &buffer]() {
+            for (int y = start_y; y < end_y; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    buffer[y * width + x] = samplePixel(x, y, width, height, camera, scene);
+                }
+                this->_completed_rows++;
+            }
+        });
+    }
+
+    workers.clear();
+    _is_rendering = false;
 }
 
 Color Renderer::samplePixel(
@@ -84,9 +98,8 @@ Color Renderer::renderFullBatch(
 }
 
 Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {
-    if (depth <= 0) {
+    if (depth <= 0)
         return Color(0, 0, 0);
-    }
 
     HitRecord rec;
     if (!scene.getWorld().hit(r, Interval(0.001, Interval::universe.max), rec)) {
@@ -96,14 +109,14 @@ Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {
         return scene.getSky().getEnvironmentColor(r);
     }
 
-    if (!rec.material) {
+    if (!rec.material)
         return Color(0, 0, 0);
-    }
 
     const IBSDF& bsdf = rec.material->getBSDF();
 
-    Color color_emitted = bsdf.emitted(rec.u, rec.v, rec.point);
+    Color ambient = computeAmbientOcclusion(r, rec, scene, bsdf, _ao_samples);
 
+    Color color_emitted = bsdf.emitted(rec.u, rec.v, rec.point);
     Color direct = computeDirectLighting(r, rec, scene, bsdf);
 
     Ray scattered;
@@ -114,7 +127,7 @@ Color Renderer::computeRayColor(const Ray& r, const Scene& scene, int depth) {
         indirect = attenuation * computeRayColor(scattered, scene, depth - 1);
     }
 
-    return color_emitted + direct + indirect;
+    return color_emitted + direct + indirect + ambient;
 }
 
 Color Renderer::computeDirectLighting(const Ray& r_in,
@@ -141,6 +154,31 @@ Color Renderer::computeDirectLighting(const Ray& r_in,
         total_direct_light += sample.color * f;
     }
     return total_direct_light;
+}
+
+Color Renderer::computeAmbientOcclusion(
+    const Ray& r, const HitRecord& rec, const Scene& scene, const IBSDF& bsdf, int samples) {
+    if (samples <= 0)
+        return Color(0, 0, 0);
+
+    Ray dummy_scattered;
+    Color albedo(1, 1, 1);
+    bsdf.scatter(r, rec, albedo, dummy_scattered);
+
+    double occlusion = 0.0;
+    for (int i = 0; i < samples; ++i) {
+        Vector3D random_dir = Vector3D::randomCosineHemisphere(rec.normal);
+        Ray ao_ray(rec.point + rec.normal * 0.001, random_dir, RayType::AMBIENT_OCCLUSION);
+
+        HitRecord ao_rec;
+        if (!scene.getWorld().hit(ao_ray, Interval(0.001, _ao_max_distance), ao_rec)) {
+            occlusion += 1.0;
+        }
+    }
+
+    const double ao_factor = occlusion / samples;
+    Color sky_color = scene.getSky().getEnvironmentColor(Ray(rec.point, rec.normal));
+    return sky_color * albedo * ao_factor * 0.15;
 }
 
 } // namespace Raytracer

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -22,6 +22,8 @@ public:
     void setSamples(int samples) { _samples = samples; }
     void setMaxDepth(int depth) { _maxDepth = depth; }
     void setAdaptiveThreshold(double threshold) { _adaptiveThreshold = threshold; }
+    void setAmbientOcclusionSamples(int samples) { _ao_samples = samples; }
+    void setAmbientOcclusionMaxDistance(double d) { _ao_max_distance = d; }
 
     int getCompletedRows() const { return _completed_rows.load(); }
     int getTotalRows() const { return _total_rows; }
@@ -36,6 +38,8 @@ private:
     int _samples;
     int _maxDepth;
     double _adaptiveThreshold = 0.1;
+    int _ao_samples = 0;
+    double _ao_max_distance = 10.0;
 
     std::atomic<int> _completed_rows{0};
     std::atomic<bool> _is_rendering{false};
@@ -48,6 +52,9 @@ private:
                                 const HitRecord& rec,
                                 const Scene& scene,
                                 const IBSDF& bsdf);
+
+    Color computeAmbientOcclusion(
+        const Ray& r, const HitRecord& rec, const Scene& scene, const IBSDF& bsdf, int samples);
 
     Color
     samplePixel(int x, int y, int width, int height, const ICamera& camera, const Scene& scene);


### PR DESCRIPTION
## FIXES

Issue #97 

## Description

Add ambient occlusion to the main renderer loop + replace tbb with jthread

### How
- Add a compute ambient occlusion with a sample parameter in the render part of the scene
- Compute multiple ray toward the sky with the normal
- Process from the amount of ray that get to the sky the value of the shadow and the ambient light 

### Testing
1. **Execution**: ./raytracer <scene> with a scene that have 16 in ao_samples
2. **Validation**: Better shadow from the corner

### Notes
- **Next**: Optimisation
- **Technical Details**: Now you can compile without the help of external tbb lib
- **Refactoring**: Better display of error when parse