### PR TITLE
Feat/reflect material

### DIFF
--- a/include/math/Vector3D.hpp
+++ b/include/math/Vector3D.hpp
@@ -6,6 +6,11 @@
 
 namespace Raytracer {
 
+struct Vector3D;
+[[nodiscard]] constexpr inline Vector3D operator+(const Vector3D& u, const Vector3D& v) noexcept;
+[[nodiscard]] constexpr inline Vector3D operator-(const Vector3D& u, const Vector3D& v) noexcept;
+[[nodiscard]] constexpr inline Vector3D operator*(double t, const Vector3D& v) noexcept;
+
 /**
  * @brief 3D vector type used for positions, directions and normals.
  */
@@ -167,6 +172,10 @@ struct Vector3D {
                 return p / std::sqrt(lensq);
             }
         }
+    }
+
+    static Vector3D reflect(Vector3D direction, Vector3D hit_normal) {
+        return direction - (2 * direction.dot(hit_normal)) * hit_normal;
     }
 };
 

--- a/scenes/mirror_box.scene
+++ b/scenes/mirror_box.scene
@@ -1,0 +1,44 @@
+camera:
+{
+    type = "perspective";
+    width = 1920;
+    height = 1080;
+    position = { x = 0.0; y = 2.0; z = 8.0; };
+    look_at = { x = 0.0; y = 0.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 60.0;
+};
+
+materials: (
+    { id = "red"; type = "metal"; color = { r = 255.0; g = 0.0; b = 0.0; }; fuzz = 0.0; },
+    { id = "obsidian"; type = "flat_color"; color = { r = 20.0; g = 20.0; b = 20.0; }; }
+);
+
+lights: (
+    { 
+        type = "directional"; 
+        rotation = { x = 45.0; y = 30.0; z = 0.0 };
+        color = { r = 200.0; g = 255.0; b = 200.0; }; 
+        intensity = 0.8;
+    }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.5; z = 0.0; }; material = "obsidian"; },
+    { 
+        type = "box"; 
+        position = { x = 0.0; y = 1.0; z = 0.0; }; 
+        rotation = { x = 45.0; y = 0.0; z = 45.0; };
+        scale = { x = 2.0; y = 2.0; z = 2.0; }; 
+        material = "red"; 
+    }
+);
+
+sky = {
+    type = "galaxy";
+    nebulaColor = { r = 10.0; g = 10.0; b = 25.0; };
+};
+
+render = {
+    samples = 32;
+}

--- a/scenes/mirror_pure.scene
+++ b/scenes/mirror_pure.scene
@@ -1,0 +1,65 @@
+camera:
+{
+    type = "perspective";
+    width = 1280;
+    height = 720;
+    position = { x = 0.0; y = 2.0; z = 10.0; };
+    look_at = { x = 0.0; y = 0.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 50.0;
+};
+
+materials: (
+    { id = "chrome"; type = "metal"; color = { r = 255.0; g = 255.0; b = 255.0; }; fuzz = 0.0; },
+    
+    { id = "floor_white"; type = "flat_color"; color = { r = 200.0; g = 200.0; b = 200.0; }; },
+    
+    { id = "bright_blue"; type = "flat_color"; color = { r = 0.0; g = 100.0; b = 255.0; }; },
+    { id = "bright_green"; type = "flat_color"; color = { r = 0.0; g = 255.0; b = 100.0; }; }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.5; z = 0.0; }; material = "floor_white"; },
+    { 
+        type = "box"; 
+        position = { x = 0.0; y = 0.5; z = 0.0; }; 
+        rotation = { x = 0.0; y = 45.0; z = 0.0; };
+        scale = { x = 2.0; y = 2.0; z = 2.0; }; 
+        material = "chrome"; 
+    },
+
+    { type = "sphere"; position = { x = -4.0; y = 0.0; z = -2.0; }; radius = 1.5; material = "bright_blue"; },
+    
+    { type = "sphere"; position = { x = 4.0; y = 0.0; z = -2.0; }; radius = 1.5; material = "bright_green"; }
+);
+
+sky = {
+    type = "atmospheric";
+    groundColor = { r = 170.0; g = 200.0; b = 255.0; };
+    zenithColor = { r = 255.0; g = 255.0; b = 255.0; };
+};
+
+lights: (
+    {
+        type = "directional";
+        rotation = { x = 35.0; y = 30.0; z = 0.0 };
+        color = { r = 255.0; g = 255.0; b = 255.0; };
+        intensity = 1.8;
+    },
+    {
+        type = "point";
+        position = { x = -6.0; y = 4.0; z = 6.0; };
+        color = { r = 255.0; g = 245.0; b = 220.0; };
+        intensity = 2.2;
+    },
+    {
+        type = "point";
+        position = { x = 6.0; y = 3.5; z = 4.0; };
+        color = { r = 220.0; g = 235.0; b = 255.0; };
+        intensity = 1.8;
+    }
+);
+
+render = {
+    samples = 32;
+};

--- a/src/materials/CMakeLists.txt
+++ b/src/materials/CMakeLists.txt
@@ -1,3 +1,28 @@
+include(FetchContent)
+
+set(SFML_STATIC_LIBRARIES OFF CACHE BOOL "" FORCE)
+set(RAYTRACER_BUILD_SHARED_LIBS_BACKUP ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS ON)
+
+find_package(SFML 3 QUIET COMPONENTS Graphics System)
+if(NOT SFML_FOUND)
+    message(STATUS "SFML not found, fetching it now")
+    FetchContent_Declare(
+        sfml
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG 3.0.0
+    )
+    set(SFML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(SFML_BUILD_DOC OFF CACHE BOOL "" FORCE)
+    set(SFML_BUILD_TEST_SUITE OFF CACHE BOOL "" FORCE)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_BACKUP ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/_deps/lib)
+    FetchContent_MakeAvailable(sfml)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY_BACKUP})
+endif()
+
+set(BUILD_SHARED_LIBS ${RAYTRACER_BUILD_SHARED_LIBS_BACKUP})
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/materials)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/materials)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/materials)
@@ -5,3 +30,4 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/materials)
 add_subdirectory(commun)
 add_subdirectory(flat_material)
 add_subdirectory(light_material)
+add_subdirectory(metal_material)

--- a/src/materials/commun/CMakeLists.txt
+++ b/src/materials/commun/CMakeLists.txt
@@ -28,6 +28,7 @@ set(BUILD_SHARED_LIBS ${RAYTRACER_BUILD_SHARED_LIBS_BACKUP})
 add_library(raytracer_materials_common STATIC
     bsdf/lambertian/LambertianBSDF.cpp
     bsdf/emissive/EmissiveBSDF.cpp
+    bsdf/metal/MetalBSDF.cpp
 )
 
 set_target_properties(raytracer_materials_common PROPERTIES

--- a/src/materials/commun/bsdf/metal/MetalBSDF.cpp
+++ b/src/materials/commun/bsdf/metal/MetalBSDF.cpp
@@ -7,21 +7,14 @@ bool MetalBSDF::scatter(const Ray& r_in,
                         Color& attenuation,
                         Ray& scattered) const {
     
-    // 1. Calculer la direction de réflexion pure (I - 2 * dot(I, N) * N)
-    // On normalise r_in.direction() pour avoir un calcul propre
     Vector3D reflected = Vector3D::reflect(r_in.direction().normalized(), hit.normal);
 
-    // 2. Ajouter le "Fuzz" (le flou)
-    // On ajoute un petit vecteur aléatoire au bout du vecteur réfléchi
     Vector3D scatter_direction = reflected + (_fuzz * Vector3D::getRandomUnitVector());
 
-    // 3. Préparer le rayon sortant
     scattered = Ray(hit.point, scatter_direction.normalized(), RayType::REFLECT);
     
-    // 4. L'atténuation est la couleur du métal
     attenuation = _albedo_texture->value(hit.u, hit.v);
 
-    // 5. Vérifier que le rayon rebondit bien vers l'extérieur (pas à travers la surface)
     return (scattered.direction().dot(hit.normal) > 0);
 }
 

--- a/src/materials/commun/bsdf/metal/MetalBSDF.cpp
+++ b/src/materials/commun/bsdf/metal/MetalBSDF.cpp
@@ -1,0 +1,28 @@
+#include "MetalBSDF.hpp"
+
+namespace Raytracer {
+
+bool MetalBSDF::scatter(const Ray& r_in,
+                        const HitRecord& hit,
+                        Color& attenuation,
+                        Ray& scattered) const {
+    
+    // 1. Calculer la direction de réflexion pure (I - 2 * dot(I, N) * N)
+    // On normalise r_in.direction() pour avoir un calcul propre
+    Vector3D reflected = Vector3D::reflect(r_in.direction().normalized(), hit.normal);
+
+    // 2. Ajouter le "Fuzz" (le flou)
+    // On ajoute un petit vecteur aléatoire au bout du vecteur réfléchi
+    Vector3D scatter_direction = reflected + (_fuzz * Vector3D::getRandomUnitVector());
+
+    // 3. Préparer le rayon sortant
+    scattered = Ray(hit.point, scatter_direction.normalized(), RayType::REFLECT);
+    
+    // 4. L'atténuation est la couleur du métal
+    attenuation = _albedo_texture->value(hit.u, hit.v);
+
+    // 5. Vérifier que le rayon rebondit bien vers l'extérieur (pas à travers la surface)
+    return (scattered.direction().dot(hit.normal) > 0);
+}
+
+}

--- a/src/materials/commun/bsdf/metal/MetalBSDF.hpp
+++ b/src/materials/commun/bsdf/metal/MetalBSDF.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "components/ITexture.hpp"
+#include "materials/commun/bsdf/ABSDF.hpp"
+#include <memory>
+
+namespace Raytracer {
+
+class MetalBSDF : public ABSDF {
+public:
+    explicit MetalBSDF(std::shared_ptr<ITexture> tex, double fuzz = 0.0)
+        : _albedo_texture(tex),
+          _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)) {}
+
+    /**
+     * @brief Sample bounce 
+     * 
+     * @param r_in 
+     * @param hit 
+     * @param attenuation 
+     * @param scattered 
+     * @return true 
+     * @return false 
+     */
+    bool scatter(const Ray& r_in,
+                 const HitRecord& hit,
+                 Color& attenuation,
+                 Ray& scattered) const override;
+
+    /**
+     * @brief Evaluate color from hit
+     * 
+     * @param light_dir 
+     * @param view_dir 
+     * @param hit 
+     * @return Color 
+     */
+    Color evaluate(const Vector3D& light_dir,
+                   const Vector3D& view_dir,
+                   const HitRecord& hit) const override {
+        return Color(0, 0, 0); 
+    }
+
+private:
+    std::shared_ptr<ITexture> _albedo_texture;
+    double _fuzz;
+};
+
+};

--- a/src/materials/flat_material/CMakeLists.txt
+++ b/src/materials/flat_material/CMakeLists.txt
@@ -2,7 +2,13 @@ add_library(raytracer_flatmaterial SHARED
     FlatMaterial.cpp
 )
 
-target_link_libraries(raytracer_flatmaterial PRIVATE raytracer_materials_common)
+if(TARGET sfml-graphics)
+    target_link_libraries(raytracer_flatmaterial PRIVATE raytracer_materials_common sfml-graphics sfml-system)
+elseif(TARGET SFML::Graphics)
+    target_link_libraries(raytracer_flatmaterial PRIVATE raytracer_materials_common SFML::Graphics SFML::System)
+else()
+    target_link_libraries(raytracer_flatmaterial PRIVATE raytracer_materials_common ${SFML_LIBRARIES})
+endif()
 
 target_include_directories(raytracer_flatmaterial PRIVATE
     ${PROJECT_SOURCE_DIR}/include

--- a/src/materials/light_material/CMakeLists.txt
+++ b/src/materials/light_material/CMakeLists.txt
@@ -2,7 +2,13 @@ add_library(raytracer_lightmaterial SHARED
     LightMaterial.cpp
 )
 
-target_link_libraries(raytracer_lightmaterial PRIVATE raytracer_materials_common)
+if(TARGET sfml-graphics)
+    target_link_libraries(raytracer_lightmaterial PRIVATE raytracer_materials_common sfml-graphics sfml-system)
+elseif(TARGET SFML::Graphics)
+    target_link_libraries(raytracer_lightmaterial PRIVATE raytracer_materials_common SFML::Graphics SFML::System)
+else()
+    target_link_libraries(raytracer_lightmaterial PRIVATE raytracer_materials_common ${SFML_LIBRARIES})
+endif()
 
 target_include_directories(raytracer_lightmaterial PRIVATE
     ${PROJECT_SOURCE_DIR}/include

--- a/src/materials/metal_material/CMakeLists.txt
+++ b/src/materials/metal_material/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_library(raytracer_metal_material SHARED
+    MetalMaterial.cpp
+)
+
+if(TARGET sfml-graphics)
+    target_link_libraries(raytracer_metal_material PRIVATE raytracer_materials_common sfml-graphics sfml-system)
+elseif(TARGET SFML::Graphics)
+    target_link_libraries(raytracer_metal_material PRIVATE raytracer_materials_common SFML::Graphics SFML::System)
+else()
+    target_link_libraries(raytracer_metal_material PRIVATE raytracer_materials_common ${SFML_LIBRARIES})
+endif()
+
+target_include_directories(raytracer_metal_material PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_compile_options(raytracer_metal_material PRIVATE
+    -W
+    -Wall
+    -Wextra
+)
+
+set_target_properties(raytracer_metal_material PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "raytracer_metal_material"
+)

--- a/src/materials/metal_material/MetalMaterial.cpp
+++ b/src/materials/metal_material/MetalMaterial.cpp
@@ -1,0 +1,20 @@
+
+#include "MetalMaterial.hpp"
+#include "materials/commun/texture/Texture.hpp"
+#include "parser/ISettings.hpp"
+
+namespace Raytracer {
+
+extern "C" {
+
+const char* getName() { return "metal"; }
+
+IMaterial* createPlugin(const ISetting& settings) {
+    double fuzz = settings.getFloat("fuzz", 0.0);
+    std::shared_ptr<ITexture> tex = Texture::fromSetting(settings, "color");
+
+    return new MetalMaterial(tex, fuzz);
+}
+}
+
+} // namespace Raytracer

--- a/src/materials/metal_material/MetalMaterial.hpp
+++ b/src/materials/metal_material/MetalMaterial.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+
+#include "components/IBSDF.hpp"
+#include "components/IMaterial.hpp"
+#include "components/ITexture.hpp"
+
+#include "materials/commun/bsdf/metal/MetalBSDF.hpp"
+
+namespace Raytracer {
+
+class MetalMaterial : public IMaterial {
+public:
+    MetalMaterial(std::shared_ptr<ITexture> tex, double fuzz = 1.0)
+        : _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)),
+          _bsdf(std::make_unique<MetalBSDF>(tex, _fuzz)) {}
+
+    const IBSDF& getBSDF() const override { return *_bsdf; }
+
+private:
+    double _fuzz;
+    std::unique_ptr<IBSDF> _bsdf; // Pre-built once at construction
+};
+
+} // namespace Raytracer

--- a/src/materials/metal_material/MetalMaterial.hpp
+++ b/src/materials/metal_material/MetalMaterial.hpp
@@ -12,7 +12,7 @@ namespace Raytracer {
 
 class MetalMaterial : public IMaterial {
 public:
-    MetalMaterial(std::shared_ptr<ITexture> tex, double fuzz = 1.0)
+    MetalMaterial(std::shared_ptr<ITexture> tex, double fuzz = 0.0)
         : _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)),
           _bsdf(std::make_unique<MetalBSDF>(tex, _fuzz)) {}
 


### PR DESCRIPTION
## FIXES

Issue #107 #105 

## Description
- BSDF class to handle specular materials. It enables objects to reflect their environment based on the laws of reflection.
- Plugin material to test the new BSDF implementation.

### How
Create MetalBSDF class to implement scatter and eval methods applying reflection laws with a possible fuzz (blur).
Create a MetalMaterial class to be able apply reflection on shapes.

### Testing
1. **Execution**: add the material to your shape with theses parameters -> id, type = "metal", color, fuzz (0.0 is pure mirror)
2. **Validation**: look at the mirror_pure.scene or the mirror_box.scene

### Notes
- **Next**: Transparent material
- **Refactoring**: Add a global SFML fetch for all materials
