### PR TITLE
Feat/material/perlin noise texture

### DIFF
--- a/include/components/ITexture.hpp
+++ b/include/components/ITexture.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "math/Color.hpp"
+#include "math/Vector3D.hpp"
 
 namespace Raytracer {
 
@@ -18,7 +19,7 @@ public:
      * @param v Vertical coordinate [0, 1].
      * @return The color at the specified mapping.
      */
-    [[nodiscard]] virtual Color value(double u, double v) const noexcept = 0;
+    [[nodiscard]] virtual Color value(double u, double v, const Vector3D& p) const noexcept = 0;
 };
 
 } // namespace Raytracer

--- a/scenes/perlin_noise.scene
+++ b/scenes/perlin_noise.scene
@@ -1,0 +1,49 @@
+camera:
+{
+    type = "perspective";
+    width = 1920;
+    height = 1080;
+    position = { x = 0.0; y = 2.0; z = 8.0; };
+    look_at = { x = 0.0; y = 0.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 60.0;
+};
+
+materials: (
+    { id = "red"; type = "flat_color"; color = {
+        type = "perlin";
+        scale = 4.0;
+        color_a = { r = 255.0; g = 0.0; b = 0.0; }; # Gris foncé
+        color_b = { r = 245.0; g = 125.0; b = 10.0; }; # Gris clair bleuté
+    }; randomness = 1.8; },
+    { id = "obsidian"; type = "flat_color"; color = { r = 10.0; g = 10.0; b = 10.0; }; }
+);
+
+lights: (
+    { 
+        type = "directional"; 
+        rotation = { x = 45.0; y = 30.0; z = 0.0 };
+        color = { r = 200.0; g = 255.0; b = 200.0; }; 
+        intensity = 0.8;
+    }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.5; z = 0.0; }; material = "obsidian"; },
+    { 
+        type = "box"; 
+        position = { x = 0.0; y = 1.0; z = 0.0; }; 
+        rotation = { x = 45.0; y = 0.0; z = 45.0; };
+        scale = { x = 2.0; y = 2.0; z = 2.0; }; 
+        material = "red"; 
+    }
+);
+
+sky = {
+    type = "galaxy";
+    nebulaColor = { r = 10.0; g = 10.0; b = 25.0; };
+};
+
+render = {
+    samples = 32;
+}

--- a/src/materials/commun/bsdf/emissive/EmissiveBSDF.hpp
+++ b/src/materials/commun/bsdf/emissive/EmissiveBSDF.hpp
@@ -42,7 +42,7 @@ public:
     Color emitted([[maybe_unused]] double u,
                   [[maybe_unused]] double v,
                   [[maybe_unused]] const Point3D& p) const override {
-        return _emission_texture->value(u, v);
+        return _emission_texture->value(u, v, p);
     }
 
 private:

--- a/src/materials/commun/bsdf/lambertian/LambertianBSDF.cpp
+++ b/src/materials/commun/bsdf/lambertian/LambertianBSDF.cpp
@@ -7,7 +7,7 @@ bool LambertianBSDF::scatter([[maybe_unused]] const Ray& r_in,
                              Color& attenuation,
                              Ray& scattered) const {
     if (_randomness <= 0.0) {
-        attenuation = _albedo_texture->value(hit.u, hit.v);
+        attenuation = _albedo_texture->value(hit.u, hit.v, hit.point);
         return false;
     }
 
@@ -20,7 +20,7 @@ bool LambertianBSDF::scatter([[maybe_unused]] const Ray& r_in,
         scatter_direction = hit.normal;
 
     scattered = Ray(hit.point, scatter_direction.normalized(), RayType::DIFFUSE);
-    attenuation = _albedo_texture->value(hit.u, hit.v);
+    attenuation = _albedo_texture->value(hit.u, hit.v, hit.point);
     return true;
 }
 
@@ -28,7 +28,7 @@ Color LambertianBSDF::evaluate(const Vector3D& light_dir,
                                [[maybe_unused]] const Vector3D& view_dir,
                                const HitRecord& hit) const {
     double cos_theta = std::max(0.0, hit.normal.dot(light_dir));
-    Color albedo = _albedo_texture->value(hit.u, hit.v);
+    Color albedo = _albedo_texture->value(hit.u, hit.v, hit.point);
     return (albedo / M_PI) * cos_theta;
 }
 

--- a/src/materials/commun/bsdf/metal/MetalBSDF.cpp
+++ b/src/materials/commun/bsdf/metal/MetalBSDF.cpp
@@ -6,16 +6,16 @@ bool MetalBSDF::scatter(const Ray& r_in,
                         const HitRecord& hit,
                         Color& attenuation,
                         Ray& scattered) const {
-    
+
     Vector3D reflected = Vector3D::reflect(r_in.direction().normalized(), hit.normal);
 
     Vector3D scatter_direction = reflected + (_fuzz * Vector3D::getRandomUnitVector());
 
     scattered = Ray(hit.point, scatter_direction.normalized(), RayType::REFLECT);
-    
-    attenuation = _albedo_texture->value(hit.u, hit.v);
+
+    attenuation = _albedo_texture->value(hit.u, hit.v, hit.point);
 
     return (scattered.direction().dot(hit.normal) > 0);
 }
 
-}
+} // namespace Raytracer

--- a/src/materials/commun/texture/ImageTexture.hpp
+++ b/src/materials/commun/texture/ImageTexture.hpp
@@ -25,7 +25,7 @@ public:
     /**
      * @brief Get color at UV coordinates.
      */
-    [[nodiscard]] Color value(double u, double v) const noexcept override {
+    [[nodiscard]] Color value(double u, double v, [[maybe_unused]] const Vector3D& p) const noexcept override {
         auto size = _image.getSize();
         if (size.x == 0 || size.y == 0)
             return Color(1, 0, 1);

--- a/src/materials/commun/texture/PerlinTexture.hpp
+++ b/src/materials/commun/texture/PerlinTexture.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "components/ITexture.hpp"
-#include <cmath>
-#include <vector>
-#include <array>
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <numeric>
 #include <random>
+#include <vector>
 
 namespace Raytracer {
 

--- a/src/materials/commun/texture/PerlinTexture.hpp
+++ b/src/materials/commun/texture/PerlinTexture.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "components/ITexture.hpp"
+#include <cmath>
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <numeric>
+#include <random>
+
+namespace Raytracer {
+
+class PerlinTexture : public ITexture {
+public:
+    PerlinTexture(double scale, Color a, Color b) : _scale(scale), _colorA(a), _colorB(b) {
+        // Initialize permutation table with values 0..255 and duplicate them
+        std::array<int, 256> p{};
+        std::iota(p.begin(), p.end(), 0);
+        // deterministic shuffle for reproducible renders
+        std::mt19937 gen(20260506);
+        std::shuffle(p.begin(), p.end(), gen);
+
+        for (int i = 0; i < 256; ++i) {
+            _permutation[i] = p[i];
+            _permutation[i + 256] = p[i];
+        }
+    }
+
+    Color value([[maybe_unused]] double u,
+                [[maybe_unused]] double v,
+                const Vector3D& p) const noexcept override {
+        Vector3D point = p * _scale;
+
+        double noiseValue = turbulence(point, 7);
+
+        return _colorA * (1.0 - noiseValue) + _colorB * noiseValue;
+    }
+
+private:
+    double _scale;
+    Color _colorA;
+    Color _colorB;
+    std::array<int, 512> _permutation;
+
+private:
+    double noise(const Vector3D& v) const {
+        Vector3D i(std::floor(v.x), std::floor(v.y), std::floor(v.z));
+        Vector3D f(v.x - i.x, v.y - i.y, v.z - i.z);
+
+        f.x = f.x * f.x * (3.0 - 2.0 * f.x);
+        f.y = f.y * f.y * (3.0 - 2.0 * f.y);
+        f.z = f.z * f.z * (3.0 - 2.0 * f.z);
+
+        return lerp3D(i, f);
+    }
+
+    double lerp3D(const Vector3D& i, const Vector3D& f) const {
+        double x0 = 1.0 - f.x, x1 = f.x;
+        double y0 = 1.0 - f.y, y1 = f.y;
+        double z0 = 1.0 - f.z, z1 = f.z;
+
+        return hash(i + Vector3D(0, 0, 0)) * x0 * y0 * z0 +
+               hash(i + Vector3D(1, 0, 0)) * x1 * y0 * z0 +
+               hash(i + Vector3D(0, 1, 0)) * x0 * y1 * z0 +
+               hash(i + Vector3D(1, 1, 0)) * x1 * y1 * z0 +
+               hash(i + Vector3D(0, 0, 1)) * x0 * y0 * z1 +
+               hash(i + Vector3D(1, 0, 1)) * x1 * y0 * z1 +
+               hash(i + Vector3D(0, 1, 1)) * x0 * y1 * z1 +
+               hash(i + Vector3D(1, 1, 1)) * x1 * y1 * z1;
+    }
+
+    double hash(const Vector3D& v) const {
+        int X = (int)std::floor(v.x) & 255;
+        int Y = (int)std::floor(v.y) & 255;
+        int Z = (int)std::floor(v.z) & 255;
+
+        int h = _permutation[_permutation[_permutation[X] + Y] + Z];
+
+        return static_cast<double>(h) / 255.0;
+    }
+
+    double turbulence(const Vector3D& p, int octaves) const {
+        double accum = 0.0;
+        Vector3D temp_p = p;
+        double weight = 0.5;
+
+        for (int i = 0; i < octaves; i++) {
+            accum += weight * noise(temp_p);
+            weight *= 0.5;
+            temp_p = temp_p * 2.0;
+        }
+        return std::abs(accum);
+    }
+};
+
+} // namespace Raytracer

--- a/src/materials/commun/texture/PerlinTexture.hpp
+++ b/src/materials/commun/texture/PerlinTexture.hpp
@@ -70,9 +70,9 @@ private:
     }
 
     double hash(const Vector3D& v) const {
-        int X = (int)std::floor(v.x) & 255;
-        int Y = (int)std::floor(v.y) & 255;
-        int Z = (int)std::floor(v.z) & 255;
+        int X = static_cast<int>(std::floor(v.x)) & 255;
+        int Y = static_cast<int>(std::floor(v.y)) & 255;
+        int Z = static_cast<int>(std::floor(v.z)) & 255;
 
         int h = _permutation[_permutation[_permutation[X] + Y] + Z];
 

--- a/src/materials/commun/texture/SolidColor.hpp
+++ b/src/materials/commun/texture/SolidColor.hpp
@@ -8,7 +8,9 @@ class SolidColor : public ITexture {
 public:
     explicit SolidColor(const Color& c) : _color(c) {}
 
-    Color value([[maybe_unused]] double u, [[maybe_unused]] double v) const noexcept override {
+    Color value([[maybe_unused]] double u,
+                [[maybe_unused]] double v,
+                [[maybe_unused]] const Vector3D& p) const noexcept override {
         return _color;
     }
 

--- a/src/materials/commun/texture/Texture.hpp
+++ b/src/materials/commun/texture/Texture.hpp
@@ -2,54 +2,88 @@
 
 #include "components/ITexture.hpp"
 #include "materials/commun/texture/ImageTexture.hpp"
+#include "materials/commun/texture/PerlinTexture.hpp"
 #include "materials/commun/texture/SolidColor.hpp"
 #include "parser/ISettings.hpp"
 #include <exception>
+#include <functional>
 #include <memory>
-#include <stdexcept>
-#include <string>
+#include <unordered_map>
 
 namespace Raytracer {
 
 /**
- * @brief Wrapper texture that can be either a solid color or an image.
- * The constructor overload determines which implementation is used.
+ * @brief Factory wrapper to create different types of textures.
+ * Allows easy extensibility for new texture types.
  */
-class Texture : public ITexture {
+class Texture {
 public:
-    explicit Texture(const Color& c) : _impl(std::make_unique<SolidColor>(c)) {}
+    using TexturePtr = std::shared_ptr<ITexture>;
+    using TextureFactory = std::function<TexturePtr(const ISetting&, const std::string&)>;
+    using ProceduralTextureFactory = std::function<TexturePtr(const std::shared_ptr<ISetting>&)>;
 
-    explicit Texture(const std::string& filename)
-        : _impl(std::make_unique<ImageTexture>(filename)) {}
-
-    static std::shared_ptr<ITexture> fromSetting(const ISetting& settings, const std::string& key) {
+    static TexturePtr fromSetting(const ISetting& settings, const std::string& key) {
         if (!settings.exists(key)) {
             throw std::runtime_error("Missing texture setting '" + key + "'.");
         }
 
-        try {
-            return std::make_shared<Texture>(settings.getColor(key));
-        } catch (const std::exception&) {
-        }
+        if (auto texture = tryCreateColor(settings, key))
+            return texture;
+        if (auto texture = tryCreateImage(settings, key))
+            return texture;
+        if (auto texture = tryCreateProcedural(settings, key))
+            return texture;
 
-        try {
-            const std::string filename = settings.getString(key);
-
-            if (filename.empty()) {
-                throw std::runtime_error("Texture path for '" + key + "' cannot be empty.");
-            }
-            return std::make_shared<Texture>(filename);
-        } catch (const std::exception&) {
-        }
-
-        throw std::runtime_error("Texture setting '" + key +
-                                 "' must be either a color ({r,g,b}) or a string path.");
+        throw std::runtime_error("Unknown texture format for key: " + key);
     }
 
-    Color value(double u, double v) const noexcept override { return _impl->value(u, v); }
-
 private:
-    std::unique_ptr<ITexture> _impl;
+    static const std::unordered_map<std::string, ProceduralTextureFactory>&
+    getProceduralFactories() {
+        static const std::unordered_map<std::string, ProceduralTextureFactory> factories = {
+            {"perlin",
+             [](const std::shared_ptr<ISetting>& group) {
+                 double scale = group->exists("scale") ? group->getFloat("scale") : 1.0;
+                 Color a = group->getColor("color_a");
+                 Color b = group->getColor("color_b");
+                 return std::make_shared<PerlinTexture>(scale, a, b);
+             }},
+        };
+        return factories;
+    }
+
+    static TexturePtr tryCreateColor(const ISetting& settings, const std::string& key) {
+        try {
+            return std::make_shared<SolidColor>(settings.getColor(key));
+        } catch (...) {
+            return nullptr;
+        }
+    }
+
+    static TexturePtr tryCreateImage(const ISetting& settings, const std::string& key) {
+        try {
+            return std::make_shared<ImageTexture>(settings.getString(key));
+        } catch (...) {
+            return nullptr;
+        }
+    }
+
+    static TexturePtr tryCreateProcedural(const ISetting& settings, const std::string& key) {
+        try {
+            auto group = settings.getGroup(key);
+            std::string type = group->getString("type");
+
+            const auto& factories = getProceduralFactories();
+            auto it = factories.find(type);
+
+            if (it == factories.end())
+                return nullptr;
+
+            return it->second(group);
+        } catch (...) {
+            return nullptr;
+        }
+    }
 };
 
 } // namespace Raytracer

--- a/src/materials/flat_material/FlatMaterial.hpp
+++ b/src/materials/flat_material/FlatMaterial.hpp
@@ -20,7 +20,7 @@ public:
 
 private:
     double _randomness;
-    std::unique_ptr<IBSDF> _bsdf; // Pre-built once at construction
+    std::unique_ptr<IBSDF> _bsdf;
 };
 
 } // namespace Raytracer


### PR DESCRIPTION
## FIXES

Issue #111 

## Description

This pull request improves the texture system and adds a new `perlin` texture implementation.

The main goals of this change are:
- add support for Perlin noise based textures;
- make the texture initialization safe and deterministic;
- prevent segmentation faults when loading a scene using `type = "perlin"`;
- keep the feature usable directly from scene configuration files.

### How

- Added a proper initialization of the Perlin permutation table in `PerlinTexture`.
- Filled the permutation array with a shuffled sequence of values from 0 to 255, then duplicated it to 512 entries.
- Kept the noise generation deterministic by using a fixed seed.
- Enabled the new `perlin` texture type in the texture factory.
- Added the `perlin_noise.scene` example to validate the feature.

### Testing
1. **Execution**: `./raytracer scenes/perlin_noise.scene`
2. **Validation**: the scene now loads and runs without segfault.

### Notes
- **Next**: if needed, the Perlin noise parameters can be exposed more explicitly in the scene config for finer artistic control.
- **Technical Details**: the crash was caused by reading from an uninitialized permutation table in `PerlinTexture`.
- **Refactoring**: the fix stays minimal and localized to the texture implementation.