### PR TITLE
feat(fractal): add Moebius strategy implementation

### DIFF
--- a/scenes/cult_of_the_moebius.scene
+++ b/scenes/cult_of_the_moebius.scene
@@ -1,0 +1,99 @@
+camera:
+{
+    type = "perspective";
+    width = 1920;
+    height = 1080;
+    position = { x = 0.0; y = 4.0; z = 15.0; }; # Reculée et montée pour voir l'allée
+    look_at = { x = 0.0; y = 1.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 60.0;
+};
+
+materials: (
+    { id = "glass";       type = "flat_color"; color = { r = 255.0; g = 255.0; b = 255.0; }; ref = 1.5; },
+    { id = "stone_floor"; type = "flat_color"; color = { r = 38.0;  g = 38.0;  b = 46.0;  }; },
+    { id = "white_wall";  type = "flat_color"; color = { r = 204.0; g = 204.0; b = 204.0; }; }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.0; z = 0.0; }; material = "stone_floor"; },
+
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_L1";
+        position = { x = -4.0; y = 0.0; z = 6.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_L2";
+        position = { x = -4.0; y = 0.0; z = 0.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_L3";
+        position = { x = -4.0; y = 0.0; z = -6.0; }; scale = 0.8;
+    },
+        { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_L1";
+        position = { x = -4.0; y = 0.0; z = -12.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_L2";
+        position = { x = -4.0; y = 0.0; z = -18.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_L3";
+        position = { x = -4.0; y = 0.0; z = -24.0; }; scale = 0.8;
+    },
+
+    # --- ALLÉE DE LANTERNES DROITE ---
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_R1";
+        position = { x = 4.0; y = 0.0; z = 6.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_R2";
+        position = { x = 4.0; y = 0.0; z = 0.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_R3";
+        position = { x = 4.0; y = 0.0; z = -6.0; }; scale = 0.8;
+    },
+        { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_R1";
+        position = { x = 4.0; y = 0.0; z = -12.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_R2";
+        position = { x = 4.0; y = 0.0; z = -18.0; }; scale = 0.8;
+    },
+    { 
+        type = "import"; path = "scenes/lantern.scene"; name = "lat_R3";
+        position = { x = 4.0; y = 0.0; z = -24.0; }; scale = 0.8;
+    },
+    { 
+        type = "fractal";
+        fractal_type = "moebius_strip";
+        max_iterations = 1;
+        position = { x = 0.0; y = 4.0; z = -25.0; }; 
+        rotation = { x = 45.0; y = 45.0; z = 0.0; }; 
+        scale = { x = 3.0; y = 3.0; z = 3.0; };
+        material = "glass";
+    }
+);
+
+lights: (
+    {
+        type = "point";
+        position = { x = 0.0; y = 1.0; z = 10.0; };
+        color = { r = 255.0; g = 140.0; b = 40.0; };
+        intensity = 3.0; 
+    }
+);
+
+sky = {
+    type = "galaxy";
+    nebulaColor = { r = 0.05; g = 0.0; b = 0.15; };
+};
+
+render = {
+    samples = 1;
+    adaptive_threshold = 0.02;
+}

--- a/src/lights/point_light/PointLight.cpp
+++ b/src/lights/point_light/PointLight.cpp
@@ -1,7 +1,6 @@
 #include "PointLight.hpp"
 #include "factory/LightFactory.hpp"
 #include "parser/ISettings.hpp"
-#include <algorithm> // Pour std::max si besoin, bien que plus nécessaire ici
 
 namespace Raytracer {
 

--- a/src/primitives/fractal/CMakeLists.txt
+++ b/src/primitives/fractal/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(raytracer_fractal SHARED
 	strategy/menger_sponge/MengerSpongeStrategy.cpp
 	strategy/mandelbulb/MandelbulbStrategy.cpp
 	strategy/moebius_strip/MoebiusStrategy.cpp
+
 	Fractal.cpp
 	FractalStrategyFactory.cpp
 )

--- a/src/primitives/fractal/CMakeLists.txt
+++ b/src/primitives/fractal/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(raytracer_fractal SHARED
 	strategy/menger_sponge/MengerSpongeStrategy.cpp
 	strategy/mandelbulb/MandelbulbStrategy.cpp
-
+	strategy/moebius_strip/MoebiusStrategy.cpp
 	Fractal.cpp
 	FractalStrategyFactory.cpp
 )

--- a/src/primitives/fractal/FractalStrategyFactory.cpp
+++ b/src/primitives/fractal/FractalStrategyFactory.cpp
@@ -3,6 +3,7 @@
 
 #include "strategy/mandelbulb/MandelbulbStrategy.hpp"
 #include "strategy/menger_sponge/MengerSpongeStrategy.hpp"
+#include "strategy/moebius_strip/MoebiusStrategy.hpp"
 
 namespace Raytracer {
 
@@ -13,9 +14,17 @@ std::unique_ptr<IFractalStrategy> FractalStrategyFactory::create(std::string typ
 
     static const std::unordered_map<std::string, StrategyCreator> strategyMap = {
         {"menger_sponge",
-         []([[maybe_unused]] const ISetting& settings) { return std::make_unique<MengerSpongeStrategy>(); }},
+         []([[maybe_unused]] const ISetting& settings) {
+             return std::make_unique<MengerSpongeStrategy>();
+         }},
         {"mandelbulb",
-         []([[maybe_unused]] const ISetting& settings) { return std::make_unique<MandelbulbStrategy>(); }},
+         []([[maybe_unused]] const ISetting& settings) {
+             return std::make_unique<MandelbulbStrategy>();
+         }},
+        {"moebius_strip",
+         []([[maybe_unused]] const ISetting& settings) {
+             return std::make_unique<MoebiusStrategy>();
+         }},
     };
 
     auto it = strategyMap.find(type);

--- a/src/primitives/fractal/strategy/moebius_strip/MoebiusStrategy.cpp
+++ b/src/primitives/fractal/strategy/moebius_strip/MoebiusStrategy.cpp
@@ -5,14 +5,14 @@
 namespace Raytracer {
 
 FractalResult MoebiusStrategy::getInfo(const Vector3D& p, [[maybe_unused]] int maxIter) const {
-    const double R = 1.0;  // Rayon du cercle principal
-    const double w = 0.4;  // Demi-largeur du ruban
-    const double t = 0.05; // Demi-épaisseur
+    const double R = 1.0;
+    const double w = 0.4;
+    const double t = 0.05;
 
     double phi = std::atan2(p.z, p.x);
 
     double dist_h = std::sqrt(p.x * p.x + p.z * p.z) - R;
-    double dist_v = p.y; // Hauteur locale
+    double dist_v = p.y;
 
     double angle = phi * 0.5;
     double cosA = std::cos(angle);

--- a/src/primitives/fractal/strategy/moebius_strip/MoebiusStrategy.cpp
+++ b/src/primitives/fractal/strategy/moebius_strip/MoebiusStrategy.cpp
@@ -1,0 +1,36 @@
+#include "MoebiusStrategy.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace Raytracer {
+
+FractalResult MoebiusStrategy::getInfo(const Vector3D& p, [[maybe_unused]] int maxIter) const {
+    const double R = 1.0;  // Rayon du cercle principal
+    const double w = 0.4;  // Demi-largeur du ruban
+    const double t = 0.05; // Demi-épaisseur
+
+    double phi = std::atan2(p.z, p.x);
+
+    double dist_h = std::sqrt(p.x * p.x + p.z * p.z) - R;
+    double dist_v = p.y; // Hauteur locale
+
+    double angle = phi * 0.5;
+    double cosA = std::cos(angle);
+    double sinA = std::sin(angle);
+
+    double u = dist_h * cosA + dist_v * sinA;
+    double v = -dist_h * sinA + dist_v * cosA;
+
+    double dx = std::abs(u) - w;
+    double dy = std::abs(v) - t;
+
+    double outsideDist =
+        std::sqrt(std::max(dx, 0.0) * std::max(dx, 0.0) + std::max(dy, 0.0) * std::max(dy, 0.0));
+    double insideDist = std::min(std::max(dx, dy), 0.0);
+
+    double finalDist = outsideDist + insideDist;
+
+    return {finalDist, 0.0};
+}
+
+} // namespace Raytracer

--- a/src/primitives/fractal/strategy/moebius_strip/MoebiusStrategy.hpp
+++ b/src/primitives/fractal/strategy/moebius_strip/MoebiusStrategy.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../IFractalStrategy.hpp"
+
+namespace Raytracer {
+
+class MoebiusStrategy : public IFractalStrategy {
+public:
+    FractalResult getInfo(const Vector3D& p, int maxIter) const override;
+
+    AABB getLocalBounds() const override { return AABB({-1.5, -0.5, -1.5}, {1.5, 0.5, 1.5}); }
+};
+
+} // namespace Raytracer


### PR DESCRIPTION
## FIXES
Closes #90 

## Description

### How
- **Möbius Strip Strategy**: Implemented `MoebiusStrategy` using a Signed Distance Function (SDF) to render a non-orientable surface through the existing Ray Marching framework.

### Testing
1. **Execution**: `./raytracer scenes/moebius_strip.scene`
2. **Visual Validation**: 
just use your eyes dammit
3. **Regression Test**: 
    - Verified `Mandelbulb` and `MengerSponge` still render correctly with the new normal computation logic.

### Notes
- **Technical Details**: The `MoebiusStrategy` uses a local cylindrical projection and a 2D rotation matrix to define the strip's torsion within a bounding box ($AABB$).
- **Refactoring**: The `Fractal` class was generalized to act as a generic Ray Marching container, allowing any primitive defined by a distance function to be integrated via the `IFractalStrategy` interface.
- **Performance**: Set the default `max_iterations` for Möbius to 1, as the SDF is analytical and does not require the iterative folding used by Mandelbulb.