### PR TITLE
fix(renderer): enhance shadow sampling and improve performance in lighting calculations

### DIFF
--- a/scenes/mirror_pure.scene
+++ b/scenes/mirror_pure.scene
@@ -61,5 +61,6 @@ lights: (
 );
 
 render = {
-    samples = 32;
+    samples = 64;
+    ao_samples = 16;
 };

--- a/scenes/sphere_two_point_lights.scene
+++ b/scenes/sphere_two_point_lights.scene
@@ -1,0 +1,46 @@
+camera:
+{
+    type = "perspective";
+    width = 1280;
+    height = 720;
+    position = { x = 0.0; y = 1.5; z = 7.0; };
+    look_at = { x = 0.0; y = 0.5; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 50.0;
+};
+
+materials: (
+    { id = "sphere_mat"; type = "flat_color"; color = { r = 220.0; g = 220.0; b = 220.0; }; randomness = 0.2; },
+    { id = "ground_mat"; type = "flat_color"; color = { r = 120.0; g = 120.0; b = 120.0; }; }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.0; z = 0.0; }; material = "ground_mat"; },
+    { type = "sphere"; position = { x = 0.0; y = 0.5; z = 0.0; }; radius = 1.5; material = "sphere_mat"; }
+);
+
+lights: (
+    {
+        type = "point";
+        position = { x = -4.5; y = 0.85; z = 0.0; };
+        color = { r = 255.0; g = 235.0; b = 210.0; };
+        intensity = 10.0;
+    },
+    {
+        type = "point";
+        position = { x = 4.5; y = 0.85; z = 0.0; };
+        color = { r = 210.0; g = 230.0; b = 255.0; };
+        intensity = 8.0;
+    }
+);
+
+sky = {
+    type = "atmospheric";
+    groundColor = { r = 160.0; g = 190.0; b = 230.0; };
+    zenithColor = { r = 240.0; g = 245.0; b = 255.0; };
+};
+
+render = {
+    samples = 32;
+    ao_samples = 0;
+};

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -19,7 +19,8 @@ void Renderer::render(const ICamera& camera, const Scene& scene, FrameBuffer& bu
     buffer.assign(width * height, Color(0, 0, 0));
 
     unsigned int num_threads = std::thread::hardware_concurrency();
-    if (num_threads == 0) num_threads = 4;
+    if (num_threads == 0)
+        num_threads = 4;
 
     std::vector<std::jthread> workers;
 
@@ -142,16 +143,27 @@ Color Renderer::computeDirectLighting(const Ray& r_in,
         if (!sample.isActive)
             continue;
 
-        Ray shadow_ray(rec.point + rec.normal * 0.001, sample.direction, RayType::SHADOW);
+        double visibility = 0.0;
+        for (int i = 0; i < _shadow_samples; ++i) {
+            Vector3D perturbed_dir = sample.direction;
+            if (_shadow_samples > 1) {
+                Vector3D random_offset = Vector3D::getRandomUnitVector() * 0.05;
+                perturbed_dir = (sample.direction + random_offset).normalized();
+            }
 
-        HitRecord shadow_rec;
-        if (scene.getWorld().hit(shadow_ray, Interval(0.001, sample.distance), shadow_rec)) {
-            continue;
+            Ray shadow_ray(rec.point + rec.normal * 0.001, perturbed_dir, RayType::SHADOW);
+
+            HitRecord shadow_rec;
+            if (!scene.getWorld().hit(shadow_ray, Interval(0.001, sample.distance), shadow_rec)) {
+                visibility += 1.0;
+            }
         }
+        visibility /= _shadow_samples;
 
-        Color f = bsdf.evaluate(sample.direction, view_dir, rec);
-
-        total_direct_light += sample.color * f;
+        if (visibility > 0.0) {
+            Color f = bsdf.evaluate(sample.direction, view_dir, rec);
+            total_direct_light += sample.color * f * visibility;
+        }
     }
     return total_direct_light;
 }

--- a/src/core/renderer/Renderer.hpp
+++ b/src/core/renderer/Renderer.hpp
@@ -24,6 +24,7 @@ public:
     void setAdaptiveThreshold(double threshold) { _adaptiveThreshold = threshold; }
     void setAmbientOcclusionSamples(int samples) { _ao_samples = samples; }
     void setAmbientOcclusionMaxDistance(double d) { _ao_max_distance = d; }
+    void setShadowSamples(int samples) { _shadow_samples = samples; }
 
     int getCompletedRows() const { return _completed_rows.load(); }
     int getTotalRows() const { return _total_rows; }
@@ -40,6 +41,7 @@ private:
     double _adaptiveThreshold = 0.1;
     int _ao_samples = 0;
     double _ao_max_distance = 10.0;
+    int _shadow_samples = 4;
 
     std::atomic<int> _completed_rows{0};
     std::atomic<bool> _is_rendering{false};

--- a/src/materials/commun/bsdf/transparent/TransparentBSDF.cpp
+++ b/src/materials/commun/bsdf/transparent/TransparentBSDF.cpp
@@ -8,7 +8,7 @@ bool TransparentBSDF::scatter(const Ray& r_in,
                         Color& attenuation,
                         Ray& scattered) const {
 
-    attenuation = _albedo_texture->value(hit.u, hit.v);
+    attenuation = _albedo_texture->value(hit.u, hit.v, hit.point);
 
     double ratio = hit.front_face ? (1.0 / _ref) : _ref;
 
@@ -33,7 +33,7 @@ Color TransparentBSDF::evaluate(const Vector3D& light_dir,
                                [[maybe_unused]] const Vector3D& view_dir,
                                const HitRecord& hit) const {
     double cos_theta = std::max(0.0, hit.normal.dot(light_dir));
-    return (_albedo_texture->value(hit.u, hit.v) / M_PI) * cos_theta;
+    return (_albedo_texture->value(hit.u, hit.v, hit.point) / M_PI) * cos_theta;
 }
 
 }


### PR DESCRIPTION
## FIXES

Issue #123 

## Description

Try to fix something that work, just need soft shadow to well see that everything is ok, i compare the output with blender

### How

- Add multiples sampling when process shadow ray

### Testing
1. **Execution**: ./raytracer <scene>
2. **Validation**: See soft shadow
