### PR TITLE
Feat/normal mapping

### DIFF
--- a/scenes/normal_mapping_all_materials.scene
+++ b/scenes/normal_mapping_all_materials.scene
@@ -1,0 +1,47 @@
+camera:
+{
+    type = "perspective";
+    width = 1280;
+    height = 720;
+    position = { x = 0.0; y = 3.0; z = 12.0; };
+    look_at = { x = 0.0; y = 0.5; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 50.0;
+};
+
+materials: (
+    { id = "phong_mat0"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.09; normal = "assets/brick.jpg"; normal_strength = 0.5; },
+    { id = "phong_mat1"; type = "transparent"; color = { r = 200.0; g = 200.0; b = 200.0; }; ref = 1.5; normal = "assets/brick.jpg"; normal_strength = 0.1;},
+    { id = "phong_mat2"; type = "metal"; color = { r = 200.0; g = 200.0; b = 200.0; }; fuzz = 0.0; normal = "assets/brick.jpg"; normal_strength = 0.5; },
+    { id = "phong_mat3"; type = "phong"; color = { r = 200.0; g = 50.0; b = 50.0; }; spec = 0.2; normal = "assets/brick.jpg"; normal_strength = 1.5; },
+    { id = "debug_white"; type = "flat_color"; color = { r = 255.0; g = 255.0; b = 255.0; }; normal = "assets/brick.jpg"; normal_strength = 1.5; },
+    { id = "ground"; type = "flat_color"; color = { r = 255.0; g = 30.0; b = 30.0; }; }
+);
+
+lights: (
+    {
+        type = "point";
+        position = { x = -4.0; y = 6.0; z = 6.0 };
+        color = { r = 255.0; g = 220.0; b = 200.0; };
+        intensity = 0.9;
+    }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.0; z = 0.0; }; material = "ground"; },
+    { type = "sphere"; position = { x = -4.0; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat0"; },
+    { type = "sphere"; position = { x = -1.5; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat1"; },
+    { type = "sphere"; position = { x = 1.5; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat2"; },
+    { type = "sphere"; position = { x = 4.0; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat3"; },
+    { type = "sphere"; position = { x = 0.0; y = 0.5; z = -4.0; }; radius = 1.0; material = "debug_white"; }
+);
+
+
+sky = {
+    type = "empty";
+};
+
+render = {
+    samples = 512;
+    ao_samples = 0;
+};

--- a/scenes/phong_normal_mapping.scene
+++ b/scenes/phong_normal_mapping.scene
@@ -1,0 +1,47 @@
+camera:
+{
+    type = "perspective";
+    width = 1280;
+    height = 720;
+    position = { x = 0.0; y = 3.0; z = 12.0; };
+    look_at = { x = 0.0; y = 0.5; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 50.0;
+};
+
+materials: (
+    { id = "phong_mat0"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.09; normal = "assets/brick.jpg"},
+    { id = "phong_mat1"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.15; },
+    { id = "phong_mat2"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.03; },
+    { id = "phong_mat3"; type = "phong"; color = { r = 200.0; g = 50.0; b = 50.0; }; spec = 0.2; normal = "assets/brick.jpg" },
+    { id = "debug_white"; type = "flat_color"; color = { r = 255.0; g = 255.0; b = 255.0; }; },
+    { id = "ground"; type = "flat_color"; color = { r = 255.0; g = 30.0; b = 30.0; }; }
+);
+
+lights: (
+    {
+        type = "point";
+        position = { x = -4.0; y = 6.0; z = 6.0 };
+        color = { r = 255.0; g = 220.0; b = 200.0; };
+        intensity = 0.9;
+    }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.0; z = 0.0; }; material = "ground"; },
+    { type = "sphere"; position = { x = -4.0; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat0"; },
+    { type = "sphere"; position = { x = -1.5; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat1"; },
+    { type = "sphere"; position = { x = 1.5; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat2"; },
+    { type = "sphere"; position = { x = 4.0; y = 0.5; z = 0.0; }; radius = 1.0; material = "phong_mat3"; },
+    { type = "sphere"; position = { x = 0.0; y = 0.5; z = -4.0; }; radius = 1.0; material = "debug_white"; }
+);
+
+
+sky = {
+    type = "empty";
+};
+
+render = {
+    samples = 512;
+    ao_samples = 0;
+};

--- a/scenes/phong_normal_mapping.scene
+++ b/scenes/phong_normal_mapping.scene
@@ -10,10 +10,10 @@ camera:
 };
 
 materials: (
-    { id = "phong_mat0"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.09; normal = "assets/brick.jpg"},
+    { id = "phong_mat0"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.09; normal = "assets/brick.jpg"; normal_strength = 0.5; },
     { id = "phong_mat1"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.15; },
     { id = "phong_mat2"; type = "phong"; color = { r = 200.0; g = 200.0; b = 200.0; }; spec = 0.03; },
-    { id = "phong_mat3"; type = "phong"; color = { r = 200.0; g = 50.0; b = 50.0; }; spec = 0.2; normal = "assets/brick.jpg" },
+    { id = "phong_mat3"; type = "phong"; color = { r = 200.0; g = 50.0; b = 50.0; }; spec = 0.2; normal = "assets/brick.jpg"; normal_strength = 1.5; },
     { id = "debug_white"; type = "flat_color"; color = { r = 255.0; g = 255.0; b = 255.0; }; },
     { id = "ground"; type = "flat_color"; color = { r = 255.0; g = 30.0; b = 30.0; }; }
 );

--- a/src/materials/commun/CMakeLists.txt
+++ b/src/materials/commun/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(raytracer_materials_common STATIC
     bsdf/metal/MetalBSDF.cpp
     bsdf/phong/PhongBSDF.cpp
     bsdf/transparent/TransparentBSDF.cpp
+    bsdf/normal_mapping/NormalMappingBSDF.cpp
 )
 
 set_target_properties(raytracer_materials_common PROPERTIES

--- a/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.cpp
+++ b/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.cpp
@@ -1,0 +1,19 @@
+#include "NormalMappingBSDF.hpp"
+
+namespace Raytracer {
+
+bool NormalMappingBSDF::scatter(const Ray& r_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const {
+    HitRecord perturbed_hit = hit;
+    perturbed_hit.normal = get_perturbed_normal(hit);
+
+    return _base->scatter(r_in, perturbed_hit, attenuation, scattered);
+}
+
+Color NormalMappingBSDF::evaluate(const Vector3D& light_dir, const Vector3D& view_dir, const HitRecord& hit) const {
+    HitRecord perturbed_hit = hit;
+    perturbed_hit.normal = get_perturbed_normal(hit);
+        
+    return _base->evaluate(light_dir, view_dir, perturbed_hit);
+}
+
+} // namespace Raytracer

--- a/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.cpp
+++ b/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.cpp
@@ -16,4 +16,23 @@ Color NormalMappingBSDF::evaluate(const Vector3D& light_dir, const Vector3D& vie
     return _base->evaluate(light_dir, view_dir, perturbed_hit);
 }
 
+Vector3D NormalMappingBSDF::get_perturbed_normal(const HitRecord& hit) const {
+
+        Color n_color = _normal_map->value(hit.u, hit.v, hit.point);
+        Vector3D local_n(2.0 * n_color.r - 1.0, 2.0 * n_color.g - 1.0, 2.0 * n_color.b - 1.0);
+
+        Vector3D up = std::fabs(hit.normal.y) < 0.999 ? Vector3D(0, 1, 0) : Vector3D(1, 0, 0);
+        Vector3D tangent = up.cross(hit.normal);
+        if (tangent.lengthSquared() < 1e-12) {
+            tangent = Vector3D(1, 0, 0).cross(hit.normal);
+        }
+        tangent = (tangent - hit.normal * hit.normal.dot(tangent)).normalized();
+        Vector3D bitangent = hit.normal.cross(tangent).normalized();
+
+        Vector3D perturbed =
+            (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
+
+        return (hit.normal * (1.0 - _strength) + perturbed * _strength).normalized();
+    }
+
 } // namespace Raytracer

--- a/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.cpp
+++ b/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.cpp
@@ -18,21 +18,21 @@ Color NormalMappingBSDF::evaluate(const Vector3D& light_dir, const Vector3D& vie
 
 Vector3D NormalMappingBSDF::get_perturbed_normal(const HitRecord& hit) const {
 
-        Color n_color = _normal_map->value(hit.u, hit.v, hit.point);
-        Vector3D local_n(2.0 * n_color.r - 1.0, 2.0 * n_color.g - 1.0, 2.0 * n_color.b - 1.0);
+    Color n_color = _normal_map->value(hit.u, hit.v, hit.point);
+    Vector3D local_n(2.0 * n_color.r - 1.0, 2.0 * n_color.g - 1.0, 2.0 * n_color.b - 1.0);
 
-        Vector3D up = std::fabs(hit.normal.y) < 0.999 ? Vector3D(0, 1, 0) : Vector3D(1, 0, 0);
-        Vector3D tangent = up.cross(hit.normal);
-        if (tangent.lengthSquared() < 1e-12) {
-            tangent = Vector3D(1, 0, 0).cross(hit.normal);
-        }
-        tangent = (tangent - hit.normal * hit.normal.dot(tangent)).normalized();
-        Vector3D bitangent = hit.normal.cross(tangent).normalized();
-
-        Vector3D perturbed =
-            (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
-
-        return (hit.normal * (1.0 - _strength) + perturbed * _strength).normalized();
+    Vector3D up = std::fabs(hit.normal.y) < 0.999 ? Vector3D(0, 1, 0) : Vector3D(1, 0, 0);
+    Vector3D tangent = up.cross(hit.normal);
+    if (tangent.lengthSquared() < 1e-12) {
+        tangent = Vector3D(1, 0, 0).cross(hit.normal);
     }
+    tangent = (tangent - hit.normal * hit.normal.dot(tangent)).normalized();
+    Vector3D bitangent = hit.normal.cross(tangent).normalized();
+
+    Vector3D perturbed =
+        (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
+
+    return (hit.normal * (1.0 - _strength) + perturbed * _strength).normalized();
+}
 
 } // namespace Raytracer

--- a/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp
+++ b/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "components/ITexture.hpp"
+#include "materials/commun/bsdf/ABSDF.hpp"
+#include <cmath>
+#include <memory>
+
+namespace Raytracer {
+
+class NormalMappingBSDF : public ABSDF {
+public:
+    NormalMappingBSDF(std::shared_ptr<ABSDF> base, std::shared_ptr<ITexture> map)
+        : _base(base), _normal_map(map) {}
+
+    Color evaluate(const Vector3D& light_dir,
+                   const Vector3D& view_dir,
+                   const HitRecord& hit) const override;
+
+    bool scatter(const Ray& r_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const override;
+
+private:
+    std::shared_ptr<ABSDF> _base;
+    std::shared_ptr<ITexture> _normal_map;
+
+    Vector3D get_perturbed_normal(const HitRecord& hit) const {
+
+        Color n_color = _normal_map->value(hit.u, hit.v, hit.point);
+        Vector3D local_n(2.0 * n_color.r - 1.0, 2.0 * n_color.g - 1.0, 2.0 * n_color.b - 1.0);
+
+        Vector3D up = std::fabs(hit.normal.y) < 0.999 ? Vector3D(0, 1, 0) : Vector3D(1, 0, 0);
+        Vector3D tangent = up.cross(hit.normal);
+        if (tangent.lengthSquared() < 1e-12) {
+            tangent = Vector3D(1, 0, 0).cross(hit.normal);
+        }
+        tangent = (tangent - hit.normal * hit.normal.dot(tangent)).normalized();
+        Vector3D bitangent = hit.normal.cross(tangent).normalized();
+
+        return (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
+    }
+};
+
+} // namespace Raytracer

--- a/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp
+++ b/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp
@@ -28,24 +28,7 @@ private:
     std::shared_ptr<ITexture> _normal_map;
     double _strength;
 
-    Vector3D get_perturbed_normal(const HitRecord& hit) const {
-
-        Color n_color = _normal_map->value(hit.u, hit.v, hit.point);
-        Vector3D local_n(2.0 * n_color.r - 1.0, 2.0 * n_color.g - 1.0, 2.0 * n_color.b - 1.0);
-
-        Vector3D up = std::fabs(hit.normal.y) < 0.999 ? Vector3D(0, 1, 0) : Vector3D(1, 0, 0);
-        Vector3D tangent = up.cross(hit.normal);
-        if (tangent.lengthSquared() < 1e-12) {
-            tangent = Vector3D(1, 0, 0).cross(hit.normal);
-        }
-        tangent = (tangent - hit.normal * hit.normal.dot(tangent)).normalized();
-        Vector3D bitangent = hit.normal.cross(tangent).normalized();
-
-        Vector3D perturbed =
-            (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
-
-        return (hit.normal * (1.0 - _strength) + perturbed * _strength).normalized();
-    }
+    Vector3D get_perturbed_normal(const HitRecord& hit) const;
 };
 
 } // namespace Raytracer

--- a/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp
+++ b/src/materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp
@@ -9,18 +9,24 @@ namespace Raytracer {
 
 class NormalMappingBSDF : public ABSDF {
 public:
-    NormalMappingBSDF(std::shared_ptr<ABSDF> base, std::shared_ptr<ITexture> map)
-        : _base(base), _normal_map(map) {}
+    NormalMappingBSDF(std::shared_ptr<ABSDF> base,
+                      std::shared_ptr<ITexture> map,
+                      double strength = 1.0)
+        : _base(base), _normal_map(map), _strength(std::max(0.0, std::min(1.0, strength))) {}
 
     Color evaluate(const Vector3D& light_dir,
                    const Vector3D& view_dir,
                    const HitRecord& hit) const override;
 
-    bool scatter(const Ray& r_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const override;
+    bool scatter(const Ray& r_in,
+                 const HitRecord& hit,
+                 Color& attenuation,
+                 Ray& scattered) const override;
 
 private:
     std::shared_ptr<ABSDF> _base;
     std::shared_ptr<ITexture> _normal_map;
+    double _strength;
 
     Vector3D get_perturbed_normal(const HitRecord& hit) const {
 
@@ -35,7 +41,10 @@ private:
         tangent = (tangent - hit.normal * hit.normal.dot(tangent)).normalized();
         Vector3D bitangent = hit.normal.cross(tangent).normalized();
 
-        return (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
+        Vector3D perturbed =
+            (tangent * local_n.x + bitangent * local_n.y + hit.normal * local_n.z).normalized();
+
+        return (hit.normal * (1.0 - _strength) + perturbed * _strength).normalized();
     }
 };
 

--- a/src/materials/flat_material/FlatMaterial.cpp
+++ b/src/materials/flat_material/FlatMaterial.cpp
@@ -1,5 +1,6 @@
 
 #include "FlatMaterial.hpp"
+#include "materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp"
 #include "materials/commun/texture/Texture.hpp"
 #include "parser/ISettings.hpp"
 
@@ -13,7 +14,15 @@ IMaterial* createPlugin(const ISetting& settings) {
     double randomness = settings.getFloat("randomness", 0.0);
     std::shared_ptr<ITexture> tex = Texture::fromSetting(settings, "color");
 
-    return new FlatMaterial(tex, randomness);
+    std::shared_ptr<IBSDF> bsdf;
+    if (settings.exists("normal")) {
+        auto phong_bsdf = std::make_shared<LambertianBSDF>(tex, randomness);
+        std::shared_ptr<ITexture> normal_texture = Texture::fromSetting(settings, "normal");
+        double normal_strength = settings.getFloat("normal_strength", 1.0);
+        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture, normal_strength);
+    }
+
+    return new FlatMaterial(tex, randomness, bsdf);
 }
 }
 

--- a/src/materials/flat_material/FlatMaterial.cpp
+++ b/src/materials/flat_material/FlatMaterial.cpp
@@ -26,4 +26,15 @@ IMaterial* createPlugin(const ISetting& settings) {
 }
 }
 
+FlatMaterial::FlatMaterial(std::shared_ptr<ITexture> tex,
+        double randomness,
+        std::shared_ptr<IBSDF> custom_bsdf)
+    : _randomness(randomness < 0.0 ? 0.0 : (randomness > 1.0 ? 1.0 : randomness)) {
+    if (custom_bsdf) {
+        _bsdf = custom_bsdf;
+    } else {
+        _bsdf = std::make_shared<LambertianBSDF>(tex, _randomness);
+    }
+}
+
 } // namespace Raytracer

--- a/src/materials/flat_material/FlatMaterial.hpp
+++ b/src/materials/flat_material/FlatMaterial.hpp
@@ -14,14 +14,7 @@ class FlatMaterial : public IMaterial {
 public:
     FlatMaterial(std::shared_ptr<ITexture> tex,
                  double randomness = 1.0,
-                 std::shared_ptr<IBSDF> custom_bsdf = nullptr)
-        : _randomness(randomness < 0.0 ? 0.0 : (randomness > 1.0 ? 1.0 : randomness)) {
-        if (custom_bsdf) {
-            _bsdf = custom_bsdf;
-        } else {
-            _bsdf = std::make_shared<LambertianBSDF>(tex, _randomness);
-        }
-    }
+                 std::shared_ptr<IBSDF> custom_bsdf = nullptr);
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 

--- a/src/materials/flat_material/FlatMaterial.hpp
+++ b/src/materials/flat_material/FlatMaterial.hpp
@@ -12,15 +12,22 @@ namespace Raytracer {
 
 class FlatMaterial : public IMaterial {
 public:
-    FlatMaterial(std::shared_ptr<ITexture> tex, double randomness = 1.0)
-        : _randomness(randomness < 0.0 ? 0.0 : (randomness > 1.0 ? 1.0 : randomness)),
-          _bsdf(std::make_unique<LambertianBSDF>(tex, _randomness)) {}
+    FlatMaterial(std::shared_ptr<ITexture> tex,
+                 double randomness = 1.0,
+                 std::shared_ptr<IBSDF> custom_bsdf = nullptr)
+        : _randomness(randomness < 0.0 ? 0.0 : (randomness > 1.0 ? 1.0 : randomness)) {
+        if (custom_bsdf) {
+            _bsdf = custom_bsdf;
+        } else {
+            _bsdf = std::make_shared<LambertianBSDF>(tex, _randomness);
+        }
+    }
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 
 private:
     double _randomness;
-    std::unique_ptr<IBSDF> _bsdf;
+    std::shared_ptr<IBSDF> _bsdf;
 };
 
 } // namespace Raytracer

--- a/src/materials/light_material/LightMaterial.cpp
+++ b/src/materials/light_material/LightMaterial.cpp
@@ -1,5 +1,6 @@
 
 #include "LightMaterial.hpp"
+#include "materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp"
 #include "materials/commun/texture/Texture.hpp"
 #include "parser/ISettings.hpp"
 
@@ -12,8 +13,25 @@ const char* getName() { return "light_material"; }
 IMaterial* createPlugin(const ISetting& settings) {
     std::shared_ptr<ITexture> tex = Texture::fromSetting(settings, "color");
 
+    std::shared_ptr<IBSDF> bsdf;
+    if (settings.exists("normal")) {
+        auto phong_bsdf = std::make_shared<EmissiveBSDF>(tex);
+        std::shared_ptr<ITexture> normal_texture = Texture::fromSetting(settings, "normal");
+        double normal_strength = settings.getFloat("normal_strength", 1.0);
+        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture, normal_strength);
+    }
+
     return new LightMaterial(tex);
 }
+}
+
+LightMaterial::LightMaterial(std::shared_ptr<ITexture> tex,
+        std::shared_ptr<IBSDF> custom_bsdf) {
+    if (custom_bsdf) {
+        _bsdf = custom_bsdf;
+    } else {
+        _bsdf = std::make_shared<EmissiveBSDF>(tex);
+    }
 }
 
 } // namespace Raytracer

--- a/src/materials/light_material/LightMaterial.hpp
+++ b/src/materials/light_material/LightMaterial.hpp
@@ -10,12 +10,13 @@ namespace Raytracer {
 
 class LightMaterial : public IMaterial {
 public:
-    LightMaterial(std::shared_ptr<ITexture> tex) : _bsdf(std::make_unique<EmissiveBSDF>(tex)) {}
+    LightMaterial(std::shared_ptr<ITexture> tex,
+        std::shared_ptr<IBSDF> custom_bsdf = nullptr);
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 
 private:
-    std::unique_ptr<IBSDF> _bsdf; // Pre-built once at construction
+    std::shared_ptr<IBSDF> _bsdf; // Pre-built once at construction
 };
 
 } // namespace Raytracer

--- a/src/materials/metal_material/MetalMaterial.cpp
+++ b/src/materials/metal_material/MetalMaterial.cpp
@@ -1,5 +1,6 @@
 
 #include "MetalMaterial.hpp"
+#include "materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp"
 #include "materials/commun/texture/Texture.hpp"
 #include "parser/ISettings.hpp"
 
@@ -13,7 +14,15 @@ IMaterial* createPlugin(const ISetting& settings) {
     double fuzz = settings.getFloat("fuzz", 0.0);
     std::shared_ptr<ITexture> tex = Texture::fromSetting(settings, "color");
 
-    return new MetalMaterial(tex, fuzz);
+    std::shared_ptr<IBSDF> bsdf;
+    if (settings.exists("normal")) {
+        auto phong_bsdf = std::make_shared<MetalBSDF>(tex, fuzz);
+        std::shared_ptr<ITexture> normal_texture = Texture::fromSetting(settings, "normal");
+        double normal_strength = settings.getFloat("normal_strength", 1.0);
+        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture, normal_strength);
+    }
+
+    return new MetalMaterial(tex, fuzz, bsdf);
 }
 }
 

--- a/src/materials/metal_material/MetalMaterial.cpp
+++ b/src/materials/metal_material/MetalMaterial.cpp
@@ -26,4 +26,14 @@ IMaterial* createPlugin(const ISetting& settings) {
 }
 }
 
+MetalMaterial::MetalMaterial(std::shared_ptr<ITexture> tex,
+                double fuzz, std::shared_ptr<IBSDF> custom_bsdf)
+    : _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)) {
+    if (custom_bsdf) {
+        _bsdf = custom_bsdf;
+    } else {
+        _bsdf = std::make_shared<MetalBSDF>(tex, _fuzz);
+    }
+}
+
 } // namespace Raytracer

--- a/src/materials/metal_material/MetalMaterial.hpp
+++ b/src/materials/metal_material/MetalMaterial.hpp
@@ -12,15 +12,22 @@ namespace Raytracer {
 
 class MetalMaterial : public IMaterial {
 public:
-    MetalMaterial(std::shared_ptr<ITexture> tex, double fuzz = 0.0)
-        : _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)),
-          _bsdf(std::make_unique<MetalBSDF>(tex, _fuzz)) {}
+    MetalMaterial(std::shared_ptr<ITexture> tex,
+                  double fuzz = 0.0,
+                  std::shared_ptr<IBSDF> custom_bsdf = nullptr)
+        : _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)) {
+        if (custom_bsdf) {
+            _bsdf = custom_bsdf;
+        } else {
+            _bsdf = std::make_shared<MetalBSDF>(tex, _fuzz);
+        }
+    }
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 
 private:
     double _fuzz;
-    std::unique_ptr<IBSDF> _bsdf; // Pre-built once at construction
+    std::shared_ptr<IBSDF> _bsdf; // Pre-built once at construction
 };
 
 } // namespace Raytracer

--- a/src/materials/metal_material/MetalMaterial.hpp
+++ b/src/materials/metal_material/MetalMaterial.hpp
@@ -14,14 +14,7 @@ class MetalMaterial : public IMaterial {
 public:
     MetalMaterial(std::shared_ptr<ITexture> tex,
                   double fuzz = 0.0,
-                  std::shared_ptr<IBSDF> custom_bsdf = nullptr)
-        : _fuzz(fuzz < 0.0 ? 0.0 : (fuzz > 1.0 ? 1.0 : fuzz)) {
-        if (custom_bsdf) {
-            _bsdf = custom_bsdf;
-        } else {
-            _bsdf = std::make_shared<MetalBSDF>(tex, _fuzz);
-        }
-    }
+                  std::shared_ptr<IBSDF> custom_bsdf = nullptr);
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 

--- a/src/materials/phong_material/PhongMaterial.cpp
+++ b/src/materials/phong_material/PhongMaterial.cpp
@@ -18,7 +18,8 @@ IMaterial* createPlugin(const ISetting& settings) {
     if (settings.exists("normal")) {
         auto phong_bsdf = std::make_shared<PhongBSDF>(tex, spec);
         std::shared_ptr<ITexture> normal_texture = Texture::fromSetting(settings, "normal");
-        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture);
+        double normal_strength = settings.getFloat("normal_strength", 1.0);
+        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture, normal_strength);
     }
 
     return new PhongMaterial(tex, spec, bsdf);

--- a/src/materials/phong_material/PhongMaterial.cpp
+++ b/src/materials/phong_material/PhongMaterial.cpp
@@ -1,5 +1,6 @@
 
 #include "PhongMaterial.hpp"
+#include "materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp"
 #include "materials/commun/texture/Texture.hpp"
 #include "parser/ISettings.hpp"
 
@@ -13,7 +14,14 @@ IMaterial* createPlugin(const ISetting& settings) {
     double spec = settings.getFloat("spec", 0.0);
     std::shared_ptr<ITexture> tex = Texture::fromSetting(settings, "color");
 
-    return new PhongMaterial(tex, spec);
+    std::shared_ptr<IBSDF> bsdf;
+    if (settings.exists("normal")) {
+        auto phong_bsdf = std::make_shared<PhongBSDF>(tex, spec);
+        std::shared_ptr<ITexture> normal_texture = Texture::fromSetting(settings, "normal");
+        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture);
+    }
+
+    return new PhongMaterial(tex, spec, bsdf);
 }
 }
 

--- a/src/materials/phong_material/PhongMaterial.cpp
+++ b/src/materials/phong_material/PhongMaterial.cpp
@@ -26,4 +26,15 @@ IMaterial* createPlugin(const ISetting& settings) {
 }
 }
 
+PhongMaterial::PhongMaterial(std::shared_ptr<ITexture> tex,
+                double spec,
+                std::shared_ptr<IBSDF> custom_bsdf)
+    : _spec(spec < 0.0 ? 0.0 : (spec > 1.0 ? 1.0 : spec)) {
+    if (custom_bsdf) {
+        _bsdf = custom_bsdf;
+    } else {
+        _bsdf = std::make_shared<PhongBSDF>(tex, _spec);
+    }
+}
+
 } // namespace Raytracer

--- a/src/materials/phong_material/PhongMaterial.hpp
+++ b/src/materials/phong_material/PhongMaterial.hpp
@@ -12,15 +12,22 @@ namespace Raytracer {
 
 class PhongMaterial : public IMaterial {
 public:
-    PhongMaterial(std::shared_ptr<ITexture> tex, double spec = 0.0)
-        : _spec(spec < 0.0 ? 0.0 : (spec > 1.0 ? 1.0 : spec)),
-          _bsdf(std::make_unique<PhongBSDF>(tex, _spec)) {}
+    PhongMaterial(std::shared_ptr<ITexture> tex,
+                  double spec = 0.0,
+                  std::shared_ptr<IBSDF> custom_bsdf = nullptr)
+        : _spec(spec < 0.0 ? 0.0 : (spec > 1.0 ? 1.0 : spec)) {
+        if (custom_bsdf) {
+            _bsdf = custom_bsdf;
+        } else {
+            _bsdf = std::make_shared<PhongBSDF>(tex, _spec);
+        }
+    }
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 
 private:
     double _spec;
-    std::unique_ptr<IBSDF> _bsdf; // Pre-built once at construction
+    std::shared_ptr<IBSDF> _bsdf;
 };
 
 } // namespace Raytracer

--- a/src/materials/phong_material/PhongMaterial.hpp
+++ b/src/materials/phong_material/PhongMaterial.hpp
@@ -14,14 +14,7 @@ class PhongMaterial : public IMaterial {
 public:
     PhongMaterial(std::shared_ptr<ITexture> tex,
                   double spec = 0.0,
-                  std::shared_ptr<IBSDF> custom_bsdf = nullptr)
-        : _spec(spec < 0.0 ? 0.0 : (spec > 1.0 ? 1.0 : spec)) {
-        if (custom_bsdf) {
-            _bsdf = custom_bsdf;
-        } else {
-            _bsdf = std::make_shared<PhongBSDF>(tex, _spec);
-        }
-    }
+                  std::shared_ptr<IBSDF> custom_bsdf = nullptr);
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 

--- a/src/materials/transparent_material/TransparentMaterial.cpp
+++ b/src/materials/transparent_material/TransparentMaterial.cpp
@@ -1,4 +1,5 @@
 #include "TransparentMaterial.hpp"
+#include "materials/commun/bsdf/normal_mapping/NormalMappingBSDF.hpp"
 #include "materials/commun/texture/Texture.hpp"
 #include "parser/ISettings.hpp"
 
@@ -12,7 +13,15 @@ IMaterial* createPlugin(const ISetting& settings) {
     double ref = settings.getFloat("ref", 0.0);
     std::shared_ptr<ITexture> tex = Texture::fromSetting(settings, "color");
 
-    return new TransparentMaterial(tex, ref);
+    std::shared_ptr<IBSDF> bsdf;
+    if (settings.exists("normal")) {
+        auto phong_bsdf = std::make_shared<TransparentBSDF>(tex, ref);
+        std::shared_ptr<ITexture> normal_texture = Texture::fromSetting(settings, "normal");
+        double normal_strength = settings.getFloat("normal_strength", 1.0);
+        bsdf = std::make_shared<NormalMappingBSDF>(phong_bsdf, normal_texture, normal_strength);
+    }
+
+    return new TransparentMaterial(tex, ref, bsdf);
 }
 }
 

--- a/src/materials/transparent_material/TransparentMaterial.cpp
+++ b/src/materials/transparent_material/TransparentMaterial.cpp
@@ -25,4 +25,15 @@ IMaterial* createPlugin(const ISetting& settings) {
 }
 }
 
+TransparentMaterial::TransparentMaterial(std::shared_ptr<ITexture> tex,
+                    double ref,
+                    std::shared_ptr<IBSDF> custom_bsdf)
+    : _ref(ref < 0.0 ? 0.0 : ref) {
+    if (custom_bsdf) {
+        _bsdf = custom_bsdf;
+    } else {
+        _bsdf = std::make_shared<TransparentBSDF>(tex, _ref);
+    }
+}
+
 } // namespace Raytracer

--- a/src/materials/transparent_material/TransparentMaterial.hpp
+++ b/src/materials/transparent_material/TransparentMaterial.hpp
@@ -14,14 +14,7 @@ class TransparentMaterial : public IMaterial {
 public:
     TransparentMaterial(std::shared_ptr<ITexture> tex,
                         double ref = 0.0,
-                        std::shared_ptr<IBSDF> custom_bsdf = nullptr)
-        : _ref(ref < 0.0 ? 0.0 : ref) {
-        if (custom_bsdf) {
-            _bsdf = custom_bsdf;
-        } else {
-            _bsdf = std::make_shared<TransparentBSDF>(tex, _ref);
-        }
-    }
+                        std::shared_ptr<IBSDF> custom_bsdf = nullptr);
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 

--- a/src/materials/transparent_material/TransparentMaterial.hpp
+++ b/src/materials/transparent_material/TransparentMaterial.hpp
@@ -12,15 +12,22 @@ namespace Raytracer {
 
 class TransparentMaterial : public IMaterial {
 public:
-    TransparentMaterial(std::shared_ptr<ITexture> tex, double ref = 0.0)
-        : _ref(ref < 0.0 ? 0.0 : ref),
-          _bsdf(std::make_unique<TransparentBSDF>(tex, _ref)) {}
+    TransparentMaterial(std::shared_ptr<ITexture> tex,
+                        double ref = 0.0,
+                        std::shared_ptr<IBSDF> custom_bsdf = nullptr)
+        : _ref(ref < 0.0 ? 0.0 : ref) {
+        if (custom_bsdf) {
+            _bsdf = custom_bsdf;
+        } else {
+            _bsdf = std::make_shared<TransparentBSDF>(tex, _ref);
+        }
+    }
 
     const IBSDF& getBSDF() const override { return *_bsdf; }
 
 private:
     double _ref;
-    std::unique_ptr<IBSDF> _bsdf; // Pre-built once at construction
+    std::shared_ptr<IBSDF> _bsdf; // Pre-built once at construction
 };
 
 } // namespace Raytracer


### PR DESCRIPTION
## FIXES

Issue #121 

## Description
Add normal mapping to apply realistic texture on materials.

### How
- Add a NormalMappingBSDF class to take a material and a texture to apply the texture on the primitive taking account of the **lights and shadows of the material**.
- Add a possible configuration for each material to take a normal mapping with a texture and a normal_strength (intensity).

### Testing
1. **Execution**: normal = "assets/brick.jpg"; normal_strength = 0.5;
3. **Validation**: ./raytracer scenes/normal_mapping_all_materials.scene


<img width="691" height="311" alt="image" src="https://github.com/user-attachments/assets/97699ea6-d661-4e1d-b98e-9fb8b2f7575c" />
