### PR TITLE
Feat/config/scene graph

### DIFF
--- a/include/components/Entity.hpp
+++ b/include/components/Entity.hpp
@@ -124,6 +124,16 @@ public:
         return true;
     }
 
+    void dump(int indent) const override {
+        std::string pad(indent, ' ');
+        std::cout << pad << "\033[1;36m[Entity]\033[0m" << std::endl;
+
+        // On demande à la primitive (Box, Sphere, etc.) de se dumper elle-même
+        if (_primitive) {
+            _primitive->dump(indent + 3);
+        }
+    }
+
     /**
      * @brief Get the entity name.
      */
@@ -145,9 +155,13 @@ public:
     void setMaterial(std::shared_ptr<IMaterial> material) noexcept { _material = material; }
 
     void setTransform(const Matrix& m) {
+        _localTransform = m; // On garde une copie de la locale
         _transform = m;
         _transform_inv = m.inverse();
     }
+
+    // Ajoute ce getter
+    [[nodiscard]] const Matrix& getLocalTransform() const noexcept { return _localTransform; }
 
     [[nodiscard]] const Matrix& getTransform() const noexcept { return _transform; }
 
@@ -201,6 +215,7 @@ private:
     std::shared_ptr<IMaterial> _material;
     Matrix _transform;
     Matrix _transform_inv;
+    Matrix _localTransform;
 };
 
 } // namespace Raytracer

--- a/include/components/Entity.hpp
+++ b/include/components/Entity.hpp
@@ -128,7 +128,6 @@ public:
         std::string pad(indent, ' ');
         std::cout << pad << "\033[1;36m[Entity]\033[0m" << std::endl;
 
-        // On demande à la primitive (Box, Sphere, etc.) de se dumper elle-même
         if (_primitive) {
             _primitive->dump(indent + 3);
         }

--- a/include/components/Entity.hpp
+++ b/include/components/Entity.hpp
@@ -155,12 +155,11 @@ public:
     void setMaterial(std::shared_ptr<IMaterial> material) noexcept { _material = material; }
 
     void setTransform(const Matrix& m) {
-        _localTransform = m; // On garde une copie de la locale
+        _localTransform = m;
         _transform = m;
         _transform_inv = m.inverse();
     }
 
-    // Ajoute ce getter
     [[nodiscard]] const Matrix& getLocalTransform() const noexcept { return _localTransform; }
 
     [[nodiscard]] const Matrix& getTransform() const noexcept { return _transform; }

--- a/include/components/IPrimitive.hpp
+++ b/include/components/IPrimitive.hpp
@@ -34,6 +34,7 @@ public:
      */
     virtual AABB getBoundingBox() const = 0;
 
+    virtual void dump(int indent = 0) const = 0;
 };
 
 } // namespace Raytracer

--- a/include/components/PrimitiveGroup.hpp
+++ b/include/components/PrimitiveGroup.hpp
@@ -70,6 +70,16 @@ public:
         }
     }
 
+    void dump(int indent) const {
+        std::string pad(indent, ' ');
+        std::cout << pad << "\033[1;32m[PrimitiveGroup]\033[0m" << std::endl;
+        std::cout << pad << "  |-- Children (" << _children.size() << "):" << std::endl;
+
+        for (const auto& child : _children) {
+            child->dump(indent + 6);
+        }
+    }
+
     /**
      * @brief Returns the list of children.
      */

--- a/scenes/box_and_childs.scene
+++ b/scenes/box_and_childs.scene
@@ -1,0 +1,65 @@
+camera:
+{
+    type = "perspective";
+    width = 1920;
+    height = 1080;
+    position = { x = 0.0; y = 2.0; z = 8.0; };
+    look_at = { x = 0.0; y = 0.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 60.0;
+};
+
+materials: (
+    { id = "red"; type = "flat_color"; color = { r = 255.0; g = 0.0; b = 0.0; }; randomness = 1.8; },
+    { id = "obsidian"; type = "flat_color"; color = { r = 20.0; g = 20.0; b = 20.0; }; }
+);
+
+lights: (
+    { 
+        type = "directional"; 
+        rotation = { x = 45.0; y = 30.0; z = 0.0 };
+        color = { r = 200.0; g = 255.0; b = 200.0; }; 
+        intensity = 0.8;
+    }
+);
+
+shapes: (
+    { type = "plane"; position = { x = 0.0; y = -1.5; z = 0.0; }; material = "obsidian"; },
+    {
+        type = "box";
+        position = { x = 2.0; y = 0.0; z = 2.0; };
+        rotation = { x = -45.0; y = 0.0; z = 0.0 };
+        material = "red";
+        childs = {
+            shapes = (
+                { 
+                    type = "sphere"; 
+                    position = { x = 2.0; y = 2.0; z = 0.0; };
+                    radius = 1.0; 
+                    material = "red"; 
+                },
+                { 
+                    type = "sphere"; 
+                    position = { x = -2.0; y = 2.0; z = 0.0; };
+                    radius = 1.0; 
+                    material = "red"; 
+                },
+                { 
+                    type = "sphere"; 
+                    position = { x = 0.0; y = 2.0; z = 0.0; };
+                    radius = 1.0; 
+                    material = "red"; 
+                }
+            );
+        };
+    }
+);
+
+sky = {
+    type = "galaxy";
+    nebulaColor = { r = 10.0; g = 10.0; b = 25.0; };
+};
+
+render = {
+    samples = 32;
+}

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -172,7 +172,7 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                 throw RenderSettingsException("render.samples must be >= 1 (received " +
                                               std::to_string(s) + ")");
             } else if (s > 100000) {
-                std::cerr << "Warning: render.samples too large, clamping to 100000" << std::endl;
+                std::cerr << "Warning: render.samples too large, clamping to 100000 << std::endl;";
                 _renderSamples = 100000;
             } else {
                 _renderSamples = s;
@@ -182,6 +182,47 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
         throw RenderSettingsException("render.samples has an invalid type (expected integer)");
     } catch (const libconfig::SettingNotFoundException&) {
         throw RenderSettingsException("render.samples is missing");
+    }
+
+    if (renderSetting.exists("adaptive_threshold")) {
+        try {
+            _renderThreshold = static_cast<double>(renderSetting["adaptive_threshold"]);
+            if (_renderThreshold < 0.0 || _renderThreshold > 1.0) {
+                std::cerr << "Warning: render.adaptive_threshold hors [0,1], défaut 0.1"
+                          << std::endl;
+                _renderThreshold = 0.1;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            std::cerr << "Warning: render.adaptive_threshold type invalide" << std::endl;
+            ;
+        }
+    }
+
+    if (renderSetting.exists("ao_samples")) {
+        try {
+            const int a = static_cast<int>(renderSetting["ao_samples"]);
+            if (a < 0) {
+                std::cerr << "Warning: render.ao_samples doit être >= 0" << std::endl;
+                ;
+            } else {
+                _aoSamples = a;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            std::cerr << "Warning: render.ao_samples type invalide" << std::endl;
+        }
+    }
+
+    if (renderSetting.exists("ao_max_distance")) {
+        try {
+            double d = static_cast<double>(renderSetting["ao_max_distance"]);
+            if (d <= 0.0) {
+                std::cerr << "Warning: render.ao_max_distance doit être > 0" << std::endl;
+            } else {
+                _aoMaxDistance = d;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            std::cerr << "Warning: render.ao_max_distance type invalide" << std::endl;
+        }
     }
 }
 

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -11,28 +11,38 @@
 namespace Raytracer {
 
 void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
+    Scope _s("loadScene(" + filePath + ")");
     libconfig::Config cfg;
 
     try {
         _manager.trackFile(filePath);
         cfg.readFile(filePath.c_str());
         const libconfig::Setting& root = cfg.getRoot();
+        DBG("Fichier lu — " << root.getLength() << " section(s) au root");
 
         if (root.exists("materials")) {
+            DBG("Section 'materials' détectée, parsing...");
             parseMaterials(root["materials"], outScene);
         }
 
         for (int i = 0; i < root.getLength(); ++i) {
             const libconfig::Setting& section = root[i];
             std::string name = section.getName();
+            DBG("Dispatch section[" << i << "] = \"" << name << "\"");
 
             auto it = _sectionDispatch.find(name);
             if (it != _sectionDispatch.end()) {
                 (this->*(it->second))(section, outScene);
+            } else {
+                DBG("  (aucun handler pour \"" << name << "\", ignoré)");
             }
         }
 
         _manager.untrackFile(filePath);
+
+    } catch (const libconfig::SettingNotFoundException& e) {
+        _manager.untrackFile(filePath);
+        throw SceneParserException(std::string("Error loading ") + filePath + ": " + e.what());
     } catch (const std::exception& e) {
         _manager.untrackFile(filePath);
         throw SceneParserException(std::string("Error loading ") + filePath + ": " + e.what());
@@ -40,17 +50,68 @@ void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
 }
 
 void SceneParser::parseShapes(const libconfig::Setting& setting, Scene& outScene) {
+    parseShapesInternal(setting, outScene, nullptr);
+}
+
+void SceneParser::parseShapesInternal(const libconfig::Setting& setting,
+                                      Scene& outScene,
+                                      PrimitiveGroup* targetGroup) {
+
     for (int i = 0; i < setting.getLength(); ++i) {
         const libconfig::Setting& shapeSetting = setting[i];
 
         if (shapeSetting.exists("path")) {
             handleImport(shapeSetting, outScene);
-        } else {
+
+        } else if (shapeSetting.exists("type")) {
+            std::string typeName = (const char*)shapeSetting["type"];
             auto primitive = handleStandardPrimitive(shapeSetting, outScene);
             if (primitive) {
-                outScene.addPrimitive(std::move(primitive));
+                if (targetGroup) {
+                    targetGroup->add(std::move(primitive));
+                } else {
+                    outScene.addPrimitive(std::move(primitive));
+                }
             }
         }
+    }
+}
+
+std::shared_ptr<IPrimitive> SceneParser::handleStandardPrimitive(const libconfig::Setting& setting,
+                                                                 Scene& outScene) {
+
+    if (!setting.exists("type")) {
+        return nullptr;
+    }
+
+    LibconfigSetting baseConfig(setting);
+
+    if (setting.exists("material")) {
+        std::string matId = (const char*)setting["material"];
+        const auto& ctxMats = _manager.getContextualMaterials(outScene.getMaterials());
+
+        PrimitiveSetting shapeConfig(baseConfig,
+                                     _manager.getContextualMaterials(outScene.getMaterials()));
+
+        std::shared_ptr<IPrimitive> primitivePtr;
+
+        if (!primitivePtr) {
+            return nullptr;
+        }
+
+        auto entity = std::dynamic_pointer_cast<Entity>(primitivePtr);
+        if (entity) {
+            entity->setTransform(_manager.getCurrentTransformation() * entity->getTransform());
+        }
+
+        if (setting.exists("childs")) {
+            bool isGrp = setting["childs"].isGroup();
+            if (isGrp) {
+                return handleChildren(setting["childs"], primitivePtr, entity, outScene);
+            }
+        }
+
+        return primitivePtr;
     }
 }
 
@@ -61,39 +122,43 @@ std::shared_ptr<IPrimitive> SceneParser::handleImport(const libconfig::Setting& 
 
     _manager.pushNamespace(name);
     _manager.pushTransformation(parseMatrix(setting));
-
     loadScene(path, outScene);
-
     _manager.popTransformation();
     _manager.popNamespace();
-
     return nullptr;
 }
 
-std::shared_ptr<IPrimitive> SceneParser::handleStandardPrimitive(const libconfig::Setting& setting,
-                                                                 Scene& outScene) {
-    LibconfigSetting baseConfig(setting);
-    PrimitiveSetting shapeConfig(baseConfig,
-                                 _manager.getContextualMaterials(outScene.getMaterials()));
+std::shared_ptr<IPrimitive> SceneParser::handleChildren(const libconfig::Setting& setting,
+                                                        std::shared_ptr<IPrimitive> parentPrimitive,
+                                                        std::shared_ptr<Entity> parentEntity,
+                                                        Scene& outScene) {
+    auto group = std::make_shared<PrimitiveGroup>();
 
-    auto primitivePtr = _factories.primitive.create(setting["type"], shapeConfig);
-    if (!primitivePtr)
-        return nullptr;
-
-    // On applique la transformation cumulative du manager
-    auto entity = std::dynamic_pointer_cast<Entity>(primitivePtr);
-    if (entity) {
-        entity->setTransform(_manager.getCurrentTransformation() * entity->getTransform());
+    if (parentPrimitive) {
+        group->add(parentPrimitive);
     }
 
-    return primitivePtr;
+    if (parentEntity) {
+        _manager.pushTransformation(parentEntity->getLocalTransform());
+    }
+
+    if (setting.exists("shapes")) {
+        parseShapesInternal(setting["shapes"], outScene, group.get());
+    }
+    if (parentEntity) {
+        _manager.popTransformation();
+    }
+    return group;
 }
 
 void SceneParser::parseCamera(const libconfig::Setting& setting, Scene& outScene) {
     LibconfigSetting cameraConfig(setting);
-    if (!cameraConfig.exists("type"))
+    if (!cameraConfig.exists("type")) {
         return;
-    auto camera = _factories.camera.create(cameraConfig.getString("type"), cameraConfig);
+    }
+    std::string camType = cameraConfig.getString("type");
+
+    std::shared_ptr<ICamera> camera;
     if (camera)
         outScene.setCamera(std::move(camera));
 }
@@ -103,7 +168,6 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
     LibconfigSetting renderConfig(renderSetting);
 
     const std::string rendererType = renderConfig.getString("type", "default");
-    _renderer = _factories.renderer.create(rendererType, renderConfig);
 
     try {
         if (renderSetting.exists("samples")) {
@@ -112,10 +176,11 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                 throw RenderSettingsException("render.samples must be >= 1 (received " +
                                               std::to_string(s) + ")");
             } else if (s > 100000) {
-                std::cerr << "Warning: render.samples too large, clamping to 100000" << std::endl;
+                std::cerr << "Warning: render.samples too large, clamping to 100000\n";
                 _renderSamples = 100000;
             } else {
                 _renderSamples = s;
+                DBG("samples=" << s);
             }
         }
     } catch (const libconfig::SettingTypeException&) {
@@ -128,13 +193,13 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
         try {
             _renderThreshold = static_cast<double>(renderSetting["adaptive_threshold"]);
             if (_renderThreshold < 0.0 || _renderThreshold > 1.0) {
-                std::cerr << "Warning: render.adaptive_threshold must be between 0.0 and 1.0, "
-                          << "using default 0.1" << std::endl;
+                std::cerr << "Warning: render.adaptive_threshold hors [0,1], défaut 0.1\n";
                 _renderThreshold = 0.1;
+            } else {
+                DBG("adaptive_threshold=" << _renderThreshold);
             }
         } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.adaptive_threshold has invalid type (expected float)"
-                      << std::endl;
+            std::cerr << "Warning: render.adaptive_threshold type invalide\n";
         }
     }
 
@@ -142,14 +207,13 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
         try {
             const int a = static_cast<int>(renderSetting["ao_samples"]);
             if (a < 0) {
-                std::cerr << "Warning: render.ao_samples must be >= 0, using default " << _aoSamples
-                          << std::endl;
+                std::cerr << "Warning: render.ao_samples doit être >= 0\n";
             } else {
                 _aoSamples = a;
+                DBG("ao_samples=" << a);
             }
         } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.ao_samples has invalid type (expected integer)"
-                      << std::endl;
+            std::cerr << "Warning: render.ao_samples type invalide\n";
         }
     }
 
@@ -157,26 +221,25 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
         try {
             double d = static_cast<double>(renderSetting["ao_max_distance"]);
             if (d <= 0.0) {
-                std::cerr << "Warning: render.ao_max_distance must be > 0, using default "
-                          << _aoMaxDistance << std::endl;
+                std::cerr << "Warning: render.ao_max_distance doit être > 0\n";
             } else {
                 _aoMaxDistance = d;
+                DBG("ao_max_distance=" << d);
             }
         } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.ao_max_distance has invalid type (expected float)"
-                      << std::endl;
+            std::cerr << "Warning: render.ao_max_distance type invalide\n";
         }
     }
 }
 
 void SceneParser::parseLights(const libconfig::Setting& setting, Scene& outScene) {
+
     for (int i = 0; i < setting.getLength(); ++i) {
         const libconfig::Setting& lightSetting = setting[i];
         LibconfigSetting lightConfig(lightSetting);
-        if (!lightConfig.exists("type"))
-            continue;
 
-        auto lightPtr = _factories.light.create(lightConfig.getString("type"), lightConfig);
+        std::shared_ptr<ILight> lightPtr;
+
         if (lightPtr) {
             Matrix worldMatrix = _manager.getCurrentTransformation();
             if (!worldMatrix.isIdentity()) {
@@ -188,26 +251,34 @@ void SceneParser::parseLights(const libconfig::Setting& setting, Scene& outScene
 }
 
 void SceneParser::parseMaterials(const libconfig::Setting& setting, Scene& outScene) {
+
     for (int i = 0; i < setting.getLength(); ++i) {
         const libconfig::Setting& mat = setting[i];
-        if (!mat.exists("type") || !mat.exists("id"))
+        if (!mat.exists("type") || !mat.exists("id")) {
             continue;
+        }
+        std::string matType = (const char*)mat["type"];
+        std::string matId = (const char*)mat["id"];
+        std::string fullKey = _manager.getFullNamespace() + matId;
 
         LibconfigSetting matConfig(mat);
-        auto material = _factories.material.create(mat["type"], matConfig);
+        std::shared_ptr<IMaterial> material;
+
         if (material) {
-            _manager.registerMaterial(mat["id"], material);
-            outScene.addMaterial(_manager.getFullNamespace() + (const char*)mat["id"],
-                                 std::move(material));
+            _manager.registerMaterial(matId, material);
+            outScene.addMaterial(fullKey, std::move(material));
         }
     }
 }
 
 void SceneParser::parseSky(const libconfig::Setting& setting, Scene& outScene) {
     LibconfigSetting skyConfig(setting);
-    if (!skyConfig.exists("type"))
+    if (!skyConfig.exists("type")) {
         return;
-    auto sky = _factories.sky.create(skyConfig.getString("type"), skyConfig);
+    }
+
+    std::shared_ptr<ISky> sky;
+
     if (sky)
         outScene.setSky(std::move(sky));
     else
@@ -216,10 +287,12 @@ void SceneParser::parseSky(const libconfig::Setting& setting, Scene& outScene) {
 
 Matrix SceneParser::parseMatrix(const libconfig::Setting& setting) {
     LibconfigSetting config(setting);
-    Vector3D pos = config.getVector("position", Vector3D(0, 0, 0));
-    Vector3D rot = config.getVector("rotation", Vector3D(0, 0, 0));
-    Vector3D scaleVec(1.0, 1.0, 1.0);
 
+    Vector3D pos = config.getVector("position", Vector3D(0, 0, 0));
+
+    Vector3D rot = config.getVector("rotation", Vector3D(0, 0, 0));
+
+    Vector3D scaleVec(1.0, 1.0, 1.0);
     if (setting.exists("scale")) {
         if (setting["scale"].isGroup()) {
             LibconfigSetting s_config(setting["scale"]);

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -31,7 +31,6 @@ void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
                 (this->*(it->second))(section, outScene);
             }
         }
-
         _manager.untrackFile(filePath);
 
     } catch (const libconfig::SettingNotFoundException& e) {
@@ -50,17 +49,12 @@ void SceneParser::parseShapes(const libconfig::Setting& setting, Scene& outScene
 void SceneParser::parseShapesInternal(const libconfig::Setting& setting,
                                       Scene& outScene,
                                       PrimitiveGroup* targetGroup) {
-
     for (int i = 0; i < setting.getLength(); ++i) {
         const libconfig::Setting& shapeSetting = setting[i];
 
-        LibconfigSetting baseConfig(shapeSetting);
-
         if (shapeSetting.exists("path")) {
             handleImport(shapeSetting, outScene);
-
         } else if (shapeSetting.exists("type")) {
-            std::string typeName = baseConfig.getString("type");
             auto primitive = handleStandardPrimitive(shapeSetting, outScene);
             if (primitive) {
                 if (targetGroup) {
@@ -75,40 +69,29 @@ void SceneParser::parseShapesInternal(const libconfig::Setting& setting,
 
 std::shared_ptr<IPrimitive> SceneParser::handleStandardPrimitive(const libconfig::Setting& setting,
                                                                  Scene& outScene) {
-
-    if (!setting.exists("type")) {
+    if (!setting.exists("type"))
         return nullptr;
-    }
 
     LibconfigSetting baseConfig(setting);
 
-    if (setting.exists("material")) {
-        std::string matId = baseConfig.getString("material");
-        const auto& ctxMats = _manager.getContextualMaterials(outScene.getMaterials());
+    PrimitiveSetting shapeConfig(baseConfig,
+                                 _manager.getContextualMaterials(outScene.getMaterials()));
 
-        PrimitiveSetting shapeConfig(baseConfig,
-                                     _manager.getContextualMaterials(outScene.getMaterials()));
+    auto primitivePtr = _factories.primitive.create(setting["type"], shapeConfig);
 
-        std::shared_ptr<IPrimitive> primitivePtr;
+    if (!primitivePtr)
+        return nullptr;
 
-        if (!primitivePtr) {
-            return nullptr;
-        }
-
-        auto entity = std::dynamic_pointer_cast<Entity>(primitivePtr);
-        if (entity) {
-            entity->setTransform(_manager.getCurrentTransformation() * entity->getTransform());
-        }
-
-        if (setting.exists("childs")) {
-            bool isGrp = setting["childs"].isGroup();
-            if (isGrp) {
-                return handleChildren(setting["childs"], primitivePtr, entity, outScene);
-            }
-        }
-
-        return primitivePtr;
+    auto entity = std::dynamic_pointer_cast<Entity>(primitivePtr);
+    if (entity) {
+        entity->setTransform(_manager.getCurrentTransformation() * entity->getTransform());
     }
+
+    if (setting.exists("childs") && setting["childs"].isGroup()) {
+        return handleChildren(setting["childs"], primitivePtr, entity, outScene);
+    }
+
+    return primitivePtr;
 }
 
 std::shared_ptr<IPrimitive> SceneParser::handleImport(const libconfig::Setting& setting,
@@ -129,110 +112,95 @@ std::shared_ptr<IPrimitive> SceneParser::handleChildren(const libconfig::Setting
                                                         std::shared_ptr<Entity> parentEntity,
                                                         Scene& outScene) {
     auto group = std::make_shared<PrimitiveGroup>();
-
-    if (parentPrimitive) {
+    if (parentPrimitive)
         group->add(parentPrimitive);
-    }
 
-    if (parentEntity) {
+    if (parentEntity)
         _manager.pushTransformation(parentEntity->getLocalTransform());
-    }
 
     if (setting.exists("shapes")) {
         parseShapesInternal(setting["shapes"], outScene, group.get());
     }
-    if (parentEntity) {
+
+    if (parentEntity)
         _manager.popTransformation();
-    }
     return group;
 }
 
 void SceneParser::parseCamera(const libconfig::Setting& setting, Scene& outScene) {
     LibconfigSetting cameraConfig(setting);
-    if (!cameraConfig.exists("type")) {
+    if (!cameraConfig.exists("type"))
         return;
-    }
-    std::string camType = cameraConfig.getString("type");
 
-    std::shared_ptr<ICamera> camera;
-    if (camera)
+    auto camera = _factories.camera.create(cameraConfig.getString("type"), cameraConfig);
+
+    if (camera) {
         outScene.setCamera(std::move(camera));
+    }
 }
 
-void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& outScene) {
-    (void)outScene;
+void SceneParser::parseRender(const libconfig::Setting& renderSetting,
+                              [[maybe_unused]] Scene& outScene) {
     LibconfigSetting renderConfig(renderSetting);
 
     const std::string rendererType = renderConfig.getString("type", "default");
+    _renderer = _factories.renderer.create(rendererType, renderConfig);
 
-    try {
-        if (renderSetting.exists("samples")) {
-            const int s = static_cast<int>(renderSetting["samples"]);
+    if (renderSetting.exists("samples")) {
+        try {
+            int s = static_cast<int>(renderSetting["samples"]);
             if (s < 1) {
-                throw RenderSettingsException("render.samples must be >= 1 (received " +
-                                              std::to_string(s) + ")");
-            } else if (s > 100000) {
-                std::cerr << "Warning: render.samples too large, clamping to 100000 << std::endl;";
-                _renderSamples = 100000;
-            } else {
-                _renderSamples = s;
+                throw RenderSettingsException("render.samples must be >= 1");
             }
+            _renderSamples = (s > 100000) ? 100000 : s;
+            if (s > 100000) {
+                std::cerr << "Warning: render.samples too large, clamped to 100000" << std::endl;
+            }
+        } catch (const libconfig::SettingTypeException&) {
+            throw RenderSettingsException("render.samples must be an integer");
         }
-    } catch (const libconfig::SettingTypeException&) {
-        throw RenderSettingsException("render.samples has an invalid type (expected integer)");
-    } catch (const libconfig::SettingNotFoundException&) {
-        throw RenderSettingsException("render.samples is missing");
     }
 
     if (renderSetting.exists("adaptive_threshold")) {
         try {
-            _renderThreshold = static_cast<double>(renderSetting["adaptive_threshold"]);
-            if (_renderThreshold < 0.0 || _renderThreshold > 1.0) {
-                std::cerr << "Warning: render.adaptive_threshold hors [0,1], défaut 0.1"
-                          << std::endl;
-                _renderThreshold = 0.1;
+            double threshold = static_cast<double>(renderSetting["adaptive_threshold"]);
+            if (threshold >= 0.0 && threshold <= 1.0) {
+                _renderThreshold = threshold;
+            } else {
+                std::cerr << "Warning: adaptive_threshold hors [0,1], défaut 0.1" << std::endl;
             }
         } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.adaptive_threshold type invalide" << std::endl;
-            ;
+            std::cerr << "Warning: adaptive_threshold type invalide" << std::endl;
         }
     }
 
     if (renderSetting.exists("ao_samples")) {
         try {
-            const int a = static_cast<int>(renderSetting["ao_samples"]);
-            if (a < 0) {
-                std::cerr << "Warning: render.ao_samples doit être >= 0" << std::endl;
-                ;
-            } else {
-                _aoSamples = a;
-            }
-        } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.ao_samples type invalide" << std::endl;
+            int aoS = static_cast<int>(renderSetting["ao_samples"]);
+            _aoSamples = (aoS >= 0) ? aoS : 0;
+        } catch (...) {
+            std::cerr << "Warning: ao_samples invalide" << std::endl;
         }
     }
 
     if (renderSetting.exists("ao_max_distance")) {
         try {
-            double d = static_cast<double>(renderSetting["ao_max_distance"]);
-            if (d <= 0.0) {
-                std::cerr << "Warning: render.ao_max_distance doit être > 0" << std::endl;
-            } else {
-                _aoMaxDistance = d;
-            }
-        } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.ao_max_distance type invalide" << std::endl;
+            double dist = static_cast<double>(renderSetting["ao_max_distance"]);
+            if (dist > 0.0)
+                _aoMaxDistance = dist;
+        } catch (...) {
+            std::cerr << "Warning: ao_max_distance invalide" << std::endl;
         }
     }
 }
 
 void SceneParser::parseLights(const libconfig::Setting& setting, Scene& outScene) {
-
     for (int i = 0; i < setting.getLength(); ++i) {
-        const libconfig::Setting& lightSetting = setting[i];
-        LibconfigSetting lightConfig(lightSetting);
+        LibconfigSetting lightConfig(setting[i]);
+        if (!lightConfig.exists("type"))
+            continue;
 
-        std::shared_ptr<ILight> lightPtr;
+        auto lightPtr = _factories.light.create(lightConfig.getString("type"), lightConfig);
 
         if (lightPtr) {
             Matrix worldMatrix = _manager.getCurrentTransformation();
@@ -245,20 +213,18 @@ void SceneParser::parseLights(const libconfig::Setting& setting, Scene& outScene
 }
 
 void SceneParser::parseMaterials(const libconfig::Setting& setting, Scene& outScene) {
-
     for (int i = 0; i < setting.getLength(); ++i) {
         const libconfig::Setting& mat = setting[i];
-        if (!mat.exists("type") || !mat.exists("id")) {
+        if (!mat.exists("type") || !mat.exists("id"))
             continue;
-        }
-        std::string matType = (const char*)mat["type"];
-        std::string matId = (const char*)mat["id"];
-        std::string fullKey = _manager.getFullNamespace() + matId;
 
+        std::string matId = (const char*)mat["id"];
         LibconfigSetting matConfig(mat);
-        std::shared_ptr<IMaterial> material;
+
+        auto material = _factories.material.create(mat["type"], matConfig);
 
         if (material) {
+            std::string fullKey = _manager.getFullNamespace() + matId;
             _manager.registerMaterial(matId, material);
             outScene.addMaterial(fullKey, std::move(material));
         }
@@ -267,23 +233,20 @@ void SceneParser::parseMaterials(const libconfig::Setting& setting, Scene& outSc
 
 void SceneParser::parseSky(const libconfig::Setting& setting, Scene& outScene) {
     LibconfigSetting skyConfig(setting);
-    if (!skyConfig.exists("type")) {
+    if (!skyConfig.exists("type"))
         return;
-    }
 
-    std::shared_ptr<ISky> sky;
+    auto sky = _factories.sky.create(skyConfig.getString("type"), skyConfig);
 
     if (sky)
         outScene.setSky(std::move(sky));
     else
-        outScene.setSky(std::make_unique<EmptySky>());
+        outScene.setSky(std::make_shared<EmptySky>());
 }
 
 Matrix SceneParser::parseMatrix(const libconfig::Setting& setting) {
     LibconfigSetting config(setting);
-
     Vector3D pos = config.getVector("position", Vector3D(0, 0, 0));
-
     Vector3D rot = config.getVector("rotation", Vector3D(0, 0, 0));
 
     Vector3D scaleVec(1.0, 1.0, 1.0);

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -19,7 +19,6 @@ void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
         const libconfig::Setting& root = cfg.getRoot();
 
         if (root.exists("materials")) {
-            DBG("Section 'materials' détectée, parsing...");
             parseMaterials(root["materials"], outScene);
         }
 
@@ -55,11 +54,13 @@ void SceneParser::parseShapesInternal(const libconfig::Setting& setting,
     for (int i = 0; i < setting.getLength(); ++i) {
         const libconfig::Setting& shapeSetting = setting[i];
 
+        LibconfigSetting baseConfig(shapeSetting);
+
         if (shapeSetting.exists("path")) {
             handleImport(shapeSetting, outScene);
 
         } else if (shapeSetting.exists("type")) {
-            std::string typeName = (const char*)shapeSetting["type"];
+            std::string typeName = baseConfig.getString("type");
             auto primitive = handleStandardPrimitive(shapeSetting, outScene);
             if (primitive) {
                 if (targetGroup) {
@@ -82,7 +83,7 @@ std::shared_ptr<IPrimitive> SceneParser::handleStandardPrimitive(const libconfig
     LibconfigSetting baseConfig(setting);
 
     if (setting.exists("material")) {
-        std::string matId = (const char*)setting["material"];
+        std::string matId = baseConfig.getString("material");
         const auto& ctxMats = _manager.getContextualMaterials(outScene.getMaterials());
 
         PrimitiveSetting shapeConfig(baseConfig,
@@ -171,7 +172,7 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                 throw RenderSettingsException("render.samples must be >= 1 (received " +
                                               std::to_string(s) + ")");
             } else if (s > 100000) {
-                std::cerr << "Warning: render.samples too large, clamping to 100000\n";
+                std::cerr << "Warning: render.samples too large, clamping to 100000" << std::endl;
                 _renderSamples = 100000;
             } else {
                 _renderSamples = s;
@@ -181,44 +182,6 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
         throw RenderSettingsException("render.samples has an invalid type (expected integer)");
     } catch (const libconfig::SettingNotFoundException&) {
         throw RenderSettingsException("render.samples is missing");
-    }
-
-    if (renderSetting.exists("adaptive_threshold")) {
-        try {
-            _renderThreshold = static_cast<double>(renderSetting["adaptive_threshold"]);
-            if (_renderThreshold < 0.0 || _renderThreshold > 1.0) {
-                std::cerr << "Warning: render.adaptive_threshold hors [0,1], défaut 0.1\n";
-                _renderThreshold = 0.1;
-            }
-        } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.adaptive_threshold type invalide\n";
-        }
-    }
-
-    if (renderSetting.exists("ao_samples")) {
-        try {
-            const int a = static_cast<int>(renderSetting["ao_samples"]);
-            if (a < 0) {
-                std::cerr << "Warning: render.ao_samples doit être >= 0\n";
-            } else {
-                _aoSamples = a;
-            }
-        } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.ao_samples type invalide\n";
-        }
-    }
-
-    if (renderSetting.exists("ao_max_distance")) {
-        try {
-            double d = static_cast<double>(renderSetting["ao_max_distance"]);
-            if (d <= 0.0) {
-                std::cerr << "Warning: render.ao_max_distance doit être > 0\n";
-            } else {
-                _aoMaxDistance = d;
-            }
-        } catch (const libconfig::SettingTypeException&) {
-            std::cerr << "Warning: render.ao_max_distance type invalide\n";
-        }
     }
 }
 

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -96,8 +96,10 @@ std::shared_ptr<IPrimitive> SceneParser::handleStandardPrimitive(const libconfig
 
 std::shared_ptr<IPrimitive> SceneParser::handleImport(const libconfig::Setting& setting,
                                                       Scene& outScene) {
-    std::string path = setting["path"];
-    std::string name = setting.exists("name") ? (const char*)setting["name"] : "sub";
+    LibconfigSetting baseConfig(setting);
+
+    std::string path = baseConfig.getString("path");
+    std::string name = baseConfig.getString("name", "sub");
 
     _manager.pushNamespace(name);
     _manager.pushTransformation(parseMatrix(setting));
@@ -218,10 +220,12 @@ void SceneParser::parseMaterials(const libconfig::Setting& setting, Scene& outSc
         if (!mat.exists("type") || !mat.exists("id"))
             continue;
 
-        std::string matId = (const char*)mat["id"];
         LibconfigSetting matConfig(mat);
 
-        auto material = _factories.material.create(mat["type"], matConfig);
+        std::string matId = matConfig.getString("id");
+        std::string matType = matConfig.getString("type");
+
+        auto material = _factories.material.create(matType, matConfig);
 
         if (material) {
             std::string fullKey = _manager.getFullNamespace() + matId;

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -11,14 +11,12 @@
 namespace Raytracer {
 
 void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
-    Scope _s("loadScene(" + filePath + ")");
     libconfig::Config cfg;
 
     try {
         _manager.trackFile(filePath);
         cfg.readFile(filePath.c_str());
         const libconfig::Setting& root = cfg.getRoot();
-        DBG("Fichier lu — " << root.getLength() << " section(s) au root");
 
         if (root.exists("materials")) {
             DBG("Section 'materials' détectée, parsing...");
@@ -28,13 +26,10 @@ void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
         for (int i = 0; i < root.getLength(); ++i) {
             const libconfig::Setting& section = root[i];
             std::string name = section.getName();
-            DBG("Dispatch section[" << i << "] = \"" << name << "\"");
 
             auto it = _sectionDispatch.find(name);
             if (it != _sectionDispatch.end()) {
                 (this->*(it->second))(section, outScene);
-            } else {
-                DBG("  (aucun handler pour \"" << name << "\", ignoré)");
             }
         }
 
@@ -180,7 +175,6 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                 _renderSamples = 100000;
             } else {
                 _renderSamples = s;
-                DBG("samples=" << s);
             }
         }
     } catch (const libconfig::SettingTypeException&) {
@@ -195,8 +189,6 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
             if (_renderThreshold < 0.0 || _renderThreshold > 1.0) {
                 std::cerr << "Warning: render.adaptive_threshold hors [0,1], défaut 0.1\n";
                 _renderThreshold = 0.1;
-            } else {
-                DBG("adaptive_threshold=" << _renderThreshold);
             }
         } catch (const libconfig::SettingTypeException&) {
             std::cerr << "Warning: render.adaptive_threshold type invalide\n";
@@ -210,7 +202,6 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                 std::cerr << "Warning: render.ao_samples doit être >= 0\n";
             } else {
                 _aoSamples = a;
-                DBG("ao_samples=" << a);
             }
         } catch (const libconfig::SettingTypeException&) {
             std::cerr << "Warning: render.ao_samples type invalide\n";
@@ -224,7 +215,6 @@ void SceneParser::parseRender(const libconfig::Setting& renderSetting, Scene& ou
                 std::cerr << "Warning: render.ao_max_distance doit être > 0\n";
             } else {
                 _aoMaxDistance = d;
-                DBG("ao_max_distance=" << d);
             }
         } catch (const libconfig::SettingTypeException&) {
             std::cerr << "Warning: render.ao_max_distance type invalide\n";

--- a/src/core/parser/SceneParser.hpp
+++ b/src/core/parser/SceneParser.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "components/Entity.hpp"
 #include "components/IRenderer.hpp"
 #include "components/SceneManager.hpp"
 #include "core/scene/Scene.hpp"
@@ -51,10 +52,17 @@ private:
     void parseSky(const libconfig::Setting& setting, Scene& outScene);
     void parseRender(const libconfig::Setting& setting, Scene& outScene);
 
+    void parseShapesInternal(const libconfig::Setting& setting,
+                             Scene& outScene,
+                             PrimitiveGroup* targetGroup);
+
     std::shared_ptr<IPrimitive> handleImport(const libconfig::Setting& setting, Scene& outScene);
     std::shared_ptr<IPrimitive> handleStandardPrimitive(const libconfig::Setting& setting,
                                                         Scene& outScene);
-
+    std::shared_ptr<IPrimitive> handleChildren(const libconfig::Setting& setting,
+                                               std::shared_ptr<IPrimitive> parentPrimitive,
+                                               std::shared_ptr<Entity> parentEntity,
+                                               Raytracer::Scene& outScene);
     Matrix parseMatrix(const libconfig::Setting& setting);
 
     SceneFactories& _factories;

--- a/src/core/scene/PrimitiveList.cpp
+++ b/src/core/scene/PrimitiveList.cpp
@@ -22,6 +22,27 @@ void PrimitiveList::clear() {
     _bvh_root = nullptr;
 }
 
+void PrimitiveList::dump(int indent) const {
+    std::string pad(indent, ' ');
+    std::cout << pad << "\033[1;34m[PrimitiveList]\033[0m (World Root)" << std::endl;
+
+    if (!_bounded_objects.empty()) {
+        std::cout << pad << "  |-- Bounded Objects (" << _bounded_objects.size()
+                  << "):" << std::endl;
+        for (const auto& obj : _bounded_objects) {
+            obj->dump(indent + 6);
+        }
+    }
+
+    if (!_unbounded_objects.empty()) {
+        std::cout << pad << "  |-- Unbounded Objects (" << _unbounded_objects.size()
+                  << "):" << std::endl;
+        for (const auto& obj : _unbounded_objects) {
+            obj->dump(indent + 6);
+        }
+    }
+}
+
 bool PrimitiveList::hit(const Ray& r, Interval ray_t, HitRecord& rec) const {
     HitRecord temp_rec;
     bool hit_anything = false;

--- a/src/core/scene/PrimitiveList.hpp
+++ b/src/core/scene/PrimitiveList.hpp
@@ -19,12 +19,14 @@ public:
     void buildBVH();
 
     AABB getBoundingBox() const override;
-    
+
     std::vector<std::shared_ptr<IPrimitive>> getObjects() const {
         std::vector<std::shared_ptr<IPrimitive>> all = _bounded_objects;
         all.insert(all.end(), _unbounded_objects.begin(), _unbounded_objects.end());
         return all;
     }
+
+    void dump(int indent = 0) const override;
 
 private:
     std::vector<std::shared_ptr<IPrimitive>> _bounded_objects;

--- a/src/core/scene/Scene.cpp
+++ b/src/core/scene/Scene.cpp
@@ -5,26 +5,32 @@
 namespace Raytracer {
 
 void Scene::dump() {
-    std::cout << "\n" << std::string(60, '=') << std::endl;
-    std::cout << "                RAYTRACER RUNTIME DIAGNOSTIC" << std::endl;
-    std::cout << std::string(60, '=') << std::endl;
+    const std::string separator(60, '=');
+    const std::string blue = "\033[1;34m";
+    const std::string green = "\033[1;32m";
+    const std::string yellow = "\033[1;33m";
+    const std::string red = "\033[1;31m";
+    const std::string reset = "\033[0m";
 
-    // 1. Matériaux : On vérifie les IDs
-    std::cout << "\n[Step 1] MATERIALS MAP" << std::endl;
+    std::cout << "\n" << blue << separator << reset << std::endl;
+    std::cout << "                RAYTRACER RUNTIME DIAGNOSTIC" << std::endl;
+    std::cout << blue << separator << reset << std::endl;
+
+    std::cout << "\n" << yellow << "[Step 1] MATERIALS MAP" << reset << std::endl;
     if (_materials.empty()) {
-        std::cout << "   /!\\ WARNING: No materials in the map. Shapes will be black." << std::endl;
+        std::cout << "   " << red << "/!\\ WARNING: No materials in the map." << reset << std::endl;
     } else {
         for (auto const& [name, mat] : _materials) {
-            std::cout << "   - [" << name << "] -> " << (mat ? "Ready" : "NULL") << std::endl;
+            std::cout << "   - [" << std::left << std::setw(15) << name << "] -> "
+                      << (mat ? green + "Ready" : red + "NULL") << reset << std::endl;
         }
     }
 
-    // 2. Caméra : On utilise getRay(0.5, 0.5) pour simuler le "regard"
-    std::cout << "\n[Step 2] CAMERA & RAYCASTING" << std::endl;
+    std::cout << "\n" << yellow << "[Step 2] CAMERA & RAYCASTING" << reset << std::endl;
     if (_camera) {
         Ray testRay = _camera->getRay(0.5, 0.5);
-        Point3D orig = testRay.origin();
-        Vector3D dir = testRay.direction();
+        auto orig = testRay.origin();
+        auto dir = testRay.direction();
 
         std::cout << "   - Resolution : " << _camera->getWidth() << "x" << _camera->getHeight()
                   << std::endl;
@@ -33,33 +39,31 @@ void Scene::dump() {
         std::cout << "   - Direction  : (" << dir.x << ", " << dir.y << ", " << dir.z << ")"
                   << std::endl;
 
-        if (dir.x == 0 && dir.y == 0 && dir.z == 0) {
-            std::cout << "   [!] ALERT: Camera direction is NULL (0,0,0)!" << std::endl;
-        }
+        if (dir.x == 0 && dir.y == 0 && dir.z == 0)
+            std::cout << "   " << red << "[!] ALERT: Camera direction is NULL (0,0,0)!" << reset
+                      << std::endl;
     } else {
-        std::cout << "   [!] ERROR: No camera detected." << std::endl;
+        std::cout << "   " << red << "[!] ERROR: No camera detected." << reset << std::endl;
     }
 
-    // 3. Lumières : Test de radiance à l'origine
-    std::cout << "\n[Step 3] LIGHTING EVALUATION" << std::endl;
+    std::cout << "\n" << yellow << "[Step 3] LIGHTING EVALUATION" << reset << std::endl;
     if (_lights.empty()) {
-        std::cout << "   [!] WARNING: No light sources found." << std::endl;
+        std::cout << "   " << red << "[!] WARNING: No light sources found." << reset << std::endl;
     } else {
         for (size_t i = 0; i < _lights.size(); ++i) {
-            // On demande à la lumière : "Que vois-tu au centre du monde (0,0,0) ?"
             auto sample = _lights[i]->computeLight(Point3D(0, 0, 0));
-            std::cout << "   - Light #" << i << " : Dist=" << sample.distance << ", Color=("
-                      << sample.color.r << "," << sample.color.g << "," << sample.color.b << ")"
-                      << " [" << (sample.isActive ? "ON" : "OFF") << "]" << std::endl;
+            std::cout << "   - Light #" << i << " : Dist=" << std::fixed << std::setprecision(2)
+                      << sample.distance << ", Color=(" << sample.color.r << "," << sample.color.g
+                      << "," << sample.color.b << ")"
+                      << " [" << (sample.isActive ? green + "ON" : red + "OFF") << reset << "]"
+                      << std::endl;
         }
     }
 
-    // 4. Objets : On compte les primitives via l'interface
-    std::cout << "\n[Step 4] WORLD OBJECTS" << std::endl;
-    // On part du principe que si getWorld() répond, la liste est là
-    std::cout << "   - World Geometry is active." << std::endl;
+    std::cout << "\n" << yellow << "[Step 4] WORLD HIERARCHY" << reset << std::endl;
+    _world.dump(3);
 
-    std::cout << "\n" << std::string(60, '=') << "\n" << std::endl;
+    std::cout << "\n" << blue << separator << reset << "\n" << std::endl;
 }
 
 } // namespace Raytracer

--- a/src/core/scene/bvh/BVHNode.hpp
+++ b/src/core/scene/bvh/BVHNode.hpp
@@ -17,6 +17,10 @@ public:
 
     AABB getBoundingBox() const override { return _bbox; }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[BVHNode]\033[0m" << std::endl;
+    }
+
 private:
     std::shared_ptr<IPrimitive> _left;
     std::shared_ptr<IPrimitive> _right;

--- a/src/primitives/box/Box.hpp
+++ b/src/primitives/box/Box.hpp
@@ -40,7 +40,11 @@ public:
      */
     Vector3D getNormalAt(const Vector3D& p) const;
 
-    AABB getBoundingBox() const override { return AABB::infinite(); }
+    AABB getBoundingBox() const override { return AABB(_min, _max); }
+
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Box]\033[0m" << std::endl;
+    }
 
 private:
     Vector3D _min;

--- a/src/primitives/cone/Cone.hpp
+++ b/src/primitives/cone/Cone.hpp
@@ -27,8 +27,10 @@ public:
      */
     bool hit(const Ray& r, Interval ray_t, HitRecord& rec) const;
 
-    AABB getBoundingBox() const override {
-        return AABB::infinite();
+    AABB getBoundingBox() const override { return AABB::infinite(); }
+
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Cone]\033[0m" << std::endl;
     }
 
 private:

--- a/src/primitives/cylinder/Cylinder.hpp
+++ b/src/primitives/cylinder/Cylinder.hpp
@@ -36,6 +36,10 @@ public:
         return AABB{_center - radiusVec, _center + radiusVec + heightVec};
     }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Cylinder]\033[0m" << std::endl;
+    }
+
 private:
     Point3D _center; // Center of the bottom base in local space
     double _radius;  // Local radius

--- a/src/primitives/fractal/Fractal.hpp
+++ b/src/primitives/fractal/Fractal.hpp
@@ -16,6 +16,10 @@ public:
 
     AABB getBoundingBox() const override { return _strategy->getLocalBounds(); }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Fractal]\033[0m" << std::endl;
+    }
+
 private:
     Vector3D computeNormal(const Vector3D& p) const;
 

--- a/src/primitives/infinite_cylinder/InfiniteCylinder.hpp
+++ b/src/primitives/infinite_cylinder/InfiniteCylinder.hpp
@@ -19,6 +19,10 @@ public:
 
     AABB getBoundingBox() const override { return AABB::infinite(); }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Cylinder]\033[0m" << std::endl;
+    }
+
 private:
     Point3D _center; // center line goes through xz at _center.xz
     double _radius;

--- a/src/primitives/limited_cone/LimitedCone.hpp
+++ b/src/primitives/limited_cone/LimitedCone.hpp
@@ -51,6 +51,10 @@ public:
         return AABB(Vector3D(-_radius, 0, -_radius), Vector3D(_radius, _height, _radius));
     }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[LimitedCone]\033[0m" << std::endl;
+    }
+
 private:
     /**
      * @brief Calculates intersection with the lateral surface of the cone.

--- a/src/primitives/mesh/Mesh.hpp
+++ b/src/primitives/mesh/Mesh.hpp
@@ -14,6 +14,10 @@ public:
     virtual bool hit(const Ray& r, Interval ray_t, HitRecord& rec) const override;
     virtual AABB getBoundingBox() const override;
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Mesh]\033[0m" << std::endl;
+    }
+
 private:
     std::shared_ptr<IPrimitive> createTriangle(const MeshData::TriangleIndices& triIdx) const;
 

--- a/src/primitives/plane/Plane.hpp
+++ b/src/primitives/plane/Plane.hpp
@@ -34,6 +34,10 @@ public:
 
     AABB getBoundingBox() const override { return AABB::infinite(); }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Plane]\033[0m" << std::endl;
+    }
+
 private:
     Vector3D _position;
     Vector3D _normal;

--- a/src/primitives/sphere/Sphere.hpp
+++ b/src/primitives/sphere/Sphere.hpp
@@ -37,6 +37,10 @@ public:
         return AABB{_center - radiusVec, _center + radiusVec};
     }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Sphere]\033[0m" << std::endl;
+    }
+
 private:
     Point3D _center;
     double _radius;

--- a/src/primitives/tanglecube/Tanglecube.hpp
+++ b/src/primitives/tanglecube/Tanglecube.hpp
@@ -27,6 +27,10 @@ public:
         return AABB{_center - halfExtent, _center + halfExtent};
     }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Tanglecube]\033[0m" << std::endl;
+    }
+
 private:
     /**
      * @brief Evaluate the tanglecube implicit function f(p) = 0

--- a/src/primitives/torus/Torus.hpp
+++ b/src/primitives/torus/Torus.hpp
@@ -39,6 +39,10 @@ public:
                     Vector3D(r_total, _minorRadius, r_total));
     }
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Torus]\033[0m" << std::endl;
+    }
+
 private:
     Math::QuarticCoeffs computeCoefficients(const Ray& r) const;
     bool

--- a/src/primitives/triangle/Triangle.hpp
+++ b/src/primitives/triangle/Triangle.hpp
@@ -17,6 +17,10 @@ public:
 
     void setExtraData(const Vector3D n[3], const double u_coords[3], const double v_coords[3]);
 
+    void dump(int indent) const override {
+        std::cout << std::string(indent, ' ') << "- \033[1;33m[Triangle]\033[0m" << std::endl;
+    }
+
 private:
     static constexpr float bounding_box_epsilon = 0.001f;
 


### PR DESCRIPTION
## FIXES

Issue #138

## Description

Cette PR introduit le support d'un **Scene Graph** (graphe de scène) hiérarchique via un parsing récursif. Désormais, chaque primitive peut posséder une section `childs`, permettant d'imbriquer des objets et des lumières qui héritent des transformations de leur parent.

### How

- **Parsing Récursif** : Implémentation de `handleChildren` et `parseShapesInternal` pour permettre une imbrication infinie d'objets.
- **Héritage des Transformations** : Utilisation du `SceneManager` pour gérer une pile (stack) de matrices. Les enfants héritent automatiquement de la position, rotation et échelle du parent.
- **Groupement de Primitives** : Création d'un `PrimitiveGroup` pour encapsuler un parent et ses enfants, facilitant la gestion de la scène et les futures optimisations (BVH).
- **Parsing Défensif** : Utilisation systématique de `libconfig::Setting::exists()` et `isGroup()` pour éviter les crashs de type `SettingNotFoundException` en cas de paramètres optionnels manquants.

### Example

```ini
shapes: (
    {
        type = "box";
        name = "desk";
        position = { x = 0.0; y = 0.0; z = 0.0; };
        childs = {
            shapes = (
                { 
                    type = "sphere"; 
                    position = { x = 0.5; y = 1.0; z = 0.5; }; 
                    material = "red"; 
                }
                { 
                    type = "sphere"; 
                    position = { x = 0.5; y = 2.0; z = 0.5; }; 
                    material = "red"; 
                }
            );
        };
        material = "obsidian";
    }
);