### PR TITLE
Feat/core/file watcher reset

### DIFF
--- a/scenes/complex /mirror_pure.scene
+++ b/scenes/complex /mirror_pure.scene
@@ -61,7 +61,7 @@ lights: (
 );
 
 render = {
-    samples = 64;
+    samples = 640;
     ao_samples = 16;
 };
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(raytracer_core STATIC
     parser/SceneParser.cpp
     display/loading_bar/LoadingBar.cpp
     logging/Logger.cpp
+    file_watcher/FileWatcher.cpp
 )
 
 target_include_directories(raytracer_core PUBLIC

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -13,7 +13,17 @@
 
 namespace Raytracer {
 
-Raytracer* Raytracer::_instance = nullptr;
+namespace {
+
+volatile std::sig_atomic_t g_stopRequested = 0;
+
+void handleSignal([[maybe_unused]] int signum) { g_stopRequested = 1; }
+
+bool signalStopRequested() { return g_stopRequested != 0; }
+
+void installSignalHandler() { std::signal(SIGINT, handleSignal); }
+
+} // namespace
 
 struct Raytracer::RenderContext {
     const ICamera& camera;
@@ -27,19 +37,8 @@ struct Raytracer::RenderContext {
     size_t pixelCount = 0;
 };
 
-namespace {
-
-void handleSignal([[maybe_unused]] int signum) {
-    if (Raytracer::getInstance()) {
-        Raytracer::getInstance()->stop();
-    }
-}
-
-} // namespace
-
 Raytracer::Raytracer(int argc, const char** argv) : _pluginLoader(_factories), _parser(_factories) {
-    _instance = this;
-    std::signal(SIGINT, handleSignal);
+    installSignalHandler();
 
     _configPath = parseConfigPath(argc, argv);
     if (_configPath.empty()) {
@@ -126,6 +125,12 @@ void Raytracer::run() {
 
     try {
         while (_exitCode == SUCCESS_STATUS) {
+            if (signalStopRequested()) {
+                stop();
+                _exitCode = ERROR_STATUS;
+                break;
+            }
+
             _reloadRequested.store(false);
 
             if (!renderSceneOnce())
@@ -216,6 +221,14 @@ void Raytracer::renderPreview(RenderContext& ctx) {
     });
 
     while (previewTask.wait_for(std::chrono::milliseconds(16)) != std::future_status::ready) {
+        if (signalStopRequested()) {
+            stop();
+            _previewRenderer->stop();
+            if (_renderer)
+                _renderer->stop();
+            break;
+        }
+
         if (_reloadRequested.load()) {
             _previewRenderer->stop();
             if (_renderer)
@@ -248,6 +261,10 @@ void Raytracer::renderPreview(RenderContext& ctx) {
         const auto minPreviewDuration = std::chrono::milliseconds(500);
         while (std::chrono::steady_clock::now() - previewStart < minPreviewDuration &&
                _graphic->isOpen()) {
+            if (signalStopRequested()) {
+                stop();
+                break;
+            }
             _graphic->refresh();
             std::this_thread::sleep_for(std::chrono::milliseconds(16));
         }
@@ -260,6 +277,14 @@ void Raytracer::renderFinal(RenderContext& ctx) {
 
     _loadingBar.start();
     while (renderTask.wait_for(std::chrono::milliseconds(16)) != std::future_status::ready) {
+        if (signalStopRequested()) {
+            stop();
+            _renderer->stop();
+            if (_previewRenderer)
+                _previewRenderer->stop();
+            break;
+        }
+
         if (_reloadRequested.load()) {
             _renderer->stop();
             if (_previewRenderer) {
@@ -348,10 +373,16 @@ void Raytracer::waitForDisplayClose() {
         return;
 
     while (_graphic->isOpen()) {
+        if (signalStopRequested()) {
+            _graphic->close();
+            break;
+        }
+
         if (_reloadRequested.load()) {
             _graphic->close();
             break;
         }
+
         _graphic->refresh();
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
     }

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -74,10 +74,16 @@ bool Raytracer::loadSceneFromConfig() {
         _graphic = _scene.getGraphic();
         _scene.buildBVH();
         return true;
+    } catch (const SceneParser::RenderSettingsException& e) {
+        std::cerr << "Scene render settings error for '" << _configPath << "': " << e.what()
+                  << std::endl;
     } catch (const SceneParser::SceneParserException& e) {
         std::cerr << "Scene parser error for '" << _configPath << "': " << e.what() << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Unexpected initialization error: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "Unknown initialization error while loading scene from '" << _configPath << "'"
+                  << std::endl;
     }
 
     _exitCode = ERROR_STATUS;
@@ -90,14 +96,24 @@ void Raytracer::startFileWatcher() {
         _fileWatcher->onFileChanged(
             [this](const std::string& path) { handleConfigFileChange(path); });
         _fileWatcherThread = std::jthread([this](std::stop_token stopToken) {
-            while (!stopToken.stop_requested()) {
-                if (_fileWatcher)
-                    _fileWatcher->update();
-                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            try {
+                while (!stopToken.stop_requested()) {
+                    if (_fileWatcher)
+                        _fileWatcher->update();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                }
+            } catch (const std::exception& e) {
+                std::cerr << "Warning: FileWatcher thread stopped after exception: " << e.what()
+                          << std::endl;
+            } catch (...) {
+                std::cerr << "Warning: FileWatcher thread stopped after unknown exception"
+                          << std::endl;
             }
         });
     } catch (const std::exception& e) {
         std::cerr << "Warning: failed to start FileWatcher: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "Warning: failed to start FileWatcher due to unknown exception" << std::endl;
     }
 }
 
@@ -147,8 +163,17 @@ void Raytracer::run() {
     } catch (const Scene::SceneException& e) {
         std::cerr << "Scene error while running render: " << e.what() << std::endl;
         _exitCode = ERROR_STATUS;
+    } catch (const SceneParser::RenderSettingsException& e) {
+        std::cerr << "Scene parser render settings error: " << e.what() << std::endl;
+        _exitCode = ERROR_STATUS;
+    } catch (const SceneParser::SceneParserException& e) {
+        std::cerr << "Scene parser error while running render: " << e.what() << std::endl;
+        _exitCode = ERROR_STATUS;
     } catch (const std::exception& e) {
         std::cerr << "Unexpected runtime error: " << e.what() << std::endl;
+        _exitCode = ERROR_STATUS;
+    } catch (...) {
+        std::cerr << "Unknown runtime error" << std::endl;
         _exitCode = ERROR_STATUS;
     }
 }
@@ -217,7 +242,19 @@ void Raytracer::renderPreview(RenderContext& ctx) {
 
     const auto previewStart = std::chrono::steady_clock::now();
     auto previewTask = std::async(std::launch::async, [&]() {
-        _previewRenderer->render(_scene, ctx.previewBuffer, &ctx.previewRows);
+        try {
+            _previewRenderer->render(_scene, ctx.previewBuffer, &ctx.previewRows);
+        } catch (const std::exception& e) {
+            std::cerr << "Preview render error: " << e.what() << std::endl;
+            _previewRenderer->stop();
+            if (_renderer)
+                _renderer->stop();
+        } catch (...) {
+            std::cerr << "Preview render error: unknown exception" << std::endl;
+            _previewRenderer->stop();
+            if (_renderer)
+                _renderer->stop();
+        }
     });
 
     while (previewTask.wait_for(std::chrono::milliseconds(16)) != std::future_status::ready) {
@@ -272,8 +309,21 @@ void Raytracer::renderPreview(RenderContext& ctx) {
 }
 
 void Raytracer::renderFinal(RenderContext& ctx) {
-    auto renderTask = std::async(
-        std::launch::async, [&]() { _renderer->render(_scene, ctx.finalBuffer, &ctx.finalRows); });
+    auto renderTask = std::async(std::launch::async, [&]() {
+        try {
+            _renderer->render(_scene, ctx.finalBuffer, &ctx.finalRows);
+        } catch (const std::exception& e) {
+            std::cerr << "Final render error: " << e.what() << std::endl;
+            _renderer->stop();
+            if (_previewRenderer)
+                _previewRenderer->stop();
+        } catch (...) {
+            std::cerr << "Final render error: unknown exception" << std::endl;
+            _renderer->stop();
+            if (_previewRenderer)
+                _previewRenderer->stop();
+        }
+    });
 
     _loadingBar.start();
     while (renderTask.wait_for(std::chrono::milliseconds(16)) != std::future_status::ready) {

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -67,6 +67,32 @@ Raytracer::Raytracer(int argc, const char** argv) : _pluginLoader(_factories), _
         _exitCode = ERROR_STATUS;
     }
     _scene.buildBVH();
+
+    try {
+        _fileWatcher = std::make_unique<FileWatcher>(_configPath);
+        _fileWatcher->onFileChanged(
+            [this](const std::string& path) { handleConfigFileChange(path); });
+        _watcherRunning.store(true);
+        _fileWatcherThread = std::thread([this]() {
+            while (_watcherRunning.load()) {
+                _fileWatcher->update();
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            }
+        });
+    } catch (const std::exception& e) {
+        std::cerr << "Warning: failed to start FileWatcher: " << e.what() << std::endl;
+    }
+}
+
+Raytracer::~Raytracer() {
+    _watcherRunning.store(false);
+    if (_fileWatcherThread.joinable())
+        _fileWatcherThread.join();
+}
+
+void Raytracer::handleConfigFileChange(const std::string& path) {
+    std::cout << "Config file changed: " << path << std::endl;
+    _reloadRequested.store(true);
 }
 
 void Raytracer::run() {
@@ -74,45 +100,62 @@ void Raytracer::run() {
         return;
 
     try {
-        if (!_renderer) {
-            std::cerr << "Error: no renderer plugin could be created from the render section"
-                      << std::endl;
-            _exitCode = ERROR_STATUS;
-            return;
-        }
+        while (_exitCode == SUCCESS_STATUS) {
+            _reloadRequested.store(false);
 
-        const auto& camera = _scene.getCamera();
-        size_t pixelCount = static_cast<size_t>(camera.getWidth()) * camera.getHeight();
-
-        RenderContext ctx{
-            .camera = camera,
-            .pixelCount = pixelCount,
-        };
-
-        ctx.previewBuffer = FrameBuffer(pixelCount, Color(0, 0, 0));
-        ctx.finalBuffer = FrameBuffer(pixelCount, Color(0, 0, 0));
-        ctx.previewRows = std::vector<std::uint8_t>(camera.getHeight(), 0);
-        ctx.finalRows = std::vector<std::uint8_t>(camera.getHeight(), 0);
-
-        if (_graphic) {
-            _graphic->setImageSize(camera.getWidth(), camera.getHeight());
-            ctx.hasDisplay = _graphic->init();
-            if (!ctx.hasDisplay) {
-                std::cerr << "Warning: Failed to initialize graphics display" << std::endl;
+            if (!_renderer) {
+                std::cerr << "Error: no renderer plugin could be created from the render section"
+                          << std::endl;
+                _exitCode = ERROR_STATUS;
+                return;
             }
+
+            const auto& camera = _scene.getCamera();
+            size_t pixelCount = static_cast<size_t>(camera.getWidth()) * camera.getHeight();
+
+            RenderContext ctx{
+                .camera = camera,
+                .pixelCount = pixelCount,
+            };
+
+            ctx.previewBuffer = FrameBuffer(pixelCount, Color(0, 0, 0));
+            ctx.finalBuffer = FrameBuffer(pixelCount, Color(0, 0, 0));
+            ctx.previewRows = std::vector<std::uint8_t>(camera.getHeight(), 0);
+            ctx.finalRows = std::vector<std::uint8_t>(camera.getHeight(), 0);
+
+            if (_graphic) {
+                _graphic->setImageSize(camera.getWidth(), camera.getHeight());
+                ctx.hasDisplay = _graphic->init();
+                if (!ctx.hasDisplay) {
+                    std::cerr << "Warning: Failed to initialize graphics display" << std::endl;
+                }
+            }
+
+            renderPreview(ctx);
+            if (_reloadRequested.load()) {
+                cleanupRenderers();
+                continue;
+            }
+
+            renderFinal(ctx);
+            if (_reloadRequested.load()) {
+                cleanupRenderers();
+                continue;
+            }
+
+            if (ctx.hasDisplay && _graphic && _graphic->isOpen()) {
+                showFinalFrame(ctx);
+                waitForDisplayClose();
+                if (_reloadRequested.load()) {
+                    cleanupRenderers();
+                    continue;
+                }
+            }
+
+            Image img(camera.getWidth(), camera.getHeight());
+            img.drawFromBuffer(ctx.finalBuffer);
+            break;
         }
-
-        renderPreview(ctx);
-
-        renderFinal(ctx);
-
-        if (ctx.hasDisplay && _graphic && _graphic->isOpen()) {
-            showFinalFrame(ctx);
-            waitForDisplayClose();
-        }
-
-        Image img(camera.getWidth(), camera.getHeight());
-        img.drawFromBuffer(ctx.finalBuffer);
 
     } catch (const Scene::SceneException& e) {
         std::cerr << "Scene error while running render: " << e.what() << std::endl;
@@ -133,6 +176,12 @@ void Raytracer::renderPreview(RenderContext& ctx) {
     });
 
     while (previewTask.wait_for(std::chrono::milliseconds(16)) != std::future_status::ready) {
+        if (_reloadRequested.load()) {
+            _previewRenderer->stop();
+            if (_renderer)
+                _renderer->stop();
+            break;
+        }
         if (ctx.hasDisplay && _graphic && !_graphic->isOpen()) {
             _previewRenderer->stop();
             _renderer->stop();
@@ -168,6 +217,13 @@ void Raytracer::renderFinal(RenderContext& ctx) {
 
     _loadingBar.start();
     while (renderTask.wait_for(std::chrono::milliseconds(16)) != std::future_status::ready) {
+        if (_reloadRequested.load()) {
+            _renderer->stop();
+            if (_previewRenderer) {
+                _previewRenderer->stop();
+            }
+            break;
+        }
         _loadingBar.update(*_renderer);
 
         if (ctx.hasDisplay) {
@@ -245,6 +301,10 @@ void Raytracer::waitForDisplayClose() {
         return;
 
     while (_graphic->isOpen()) {
+        if (_reloadRequested.load()) {
+            _graphic->close();
+            break;
+        }
         _graphic->refresh();
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
     }

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -90,9 +90,8 @@ void Raytracer::startFileWatcher() {
         _fileWatcher = std::make_unique<FileWatcher>(_configPath);
         _fileWatcher->onFileChanged(
             [this](const std::string& path) { handleConfigFileChange(path); });
-        _watcherRunning.store(true);
-        _fileWatcherThread = std::thread([this]() {
-            while (_watcherRunning.load()) {
+        _fileWatcherThread = std::jthread([this](std::stop_token stopToken) {
+            while (!stopToken.stop_requested()) {
                 if (_fileWatcher)
                     _fileWatcher->update();
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -104,9 +103,11 @@ void Raytracer::startFileWatcher() {
 }
 
 void Raytracer::stopFileWatcher() {
-    _watcherRunning.store(false);
-    if (_fileWatcherThread.joinable())
+    if (_fileWatcherThread.joinable()) {
+        _fileWatcherThread.request_stop();
         _fileWatcherThread.join();
+    }
+    _fileWatcher.reset();
 }
 
 bool Raytracer::reloadScene() {

--- a/src/core/Raytracer.cpp
+++ b/src/core/Raytracer.cpp
@@ -1,12 +1,14 @@
 #include "Raytracer.hpp"
 #include "core/image/Image.hpp"
 #include "parser/SceneParser.hpp"
+
 #include <atomic>
 #include <chrono>
 #include <csignal>
-#include <filesystem>
+#include <cstdint>
 #include <future>
 #include <iostream>
+#include <mutex>
 #include <thread>
 
 namespace Raytracer {
@@ -25,49 +27,65 @@ struct Raytracer::RenderContext {
     size_t pixelCount = 0;
 };
 
+namespace {
+
 void handleSignal([[maybe_unused]] int signum) {
     if (Raytracer::getInstance()) {
         Raytracer::getInstance()->stop();
     }
 }
 
+} // namespace
+
 Raytracer::Raytracer(int argc, const char** argv) : _pluginLoader(_factories), _parser(_factories) {
     _instance = this;
-
     std::signal(SIGINT, handleSignal);
 
-    std::string configPath;
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        if (configPath.empty() && arg[0] != '-') {
-            configPath = arg;
-        }
-    }
-
-    if (configPath.empty()) {
+    _configPath = parseConfigPath(argc, argv);
+    if (_configPath.empty()) {
         std::cerr << "Error: No configuration file provided." << std::endl;
         std::cerr << "Usage: ./raytracer <config_file.cfg>" << std::endl;
         _exitCode = ERROR_STATUS;
         return;
     }
 
-    _configPath = configPath;
+    if (!loadSceneFromConfig())
+        return;
 
+    startFileWatcher();
+}
+
+Raytracer::~Raytracer() { stopFileWatcher(); }
+
+std::string Raytracer::parseConfigPath(int argc, const char** argv) const {
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (!arg.empty() && arg[0] != '-')
+            return arg;
+    }
+    return {};
+}
+
+bool Raytracer::loadSceneFromConfig() {
     try {
         _pluginLoader.loadPlugins("plugins");
-        _parser.loadScene(configPath, _scene);
+        _parser.loadScene(_configPath, _scene);
         _renderer = _parser.getRenderer();
         _previewRenderer = _parser.getPreviewRenderer();
         _graphic = _scene.getGraphic();
+        _scene.buildBVH();
+        return true;
     } catch (const SceneParser::SceneParserException& e) {
-        std::cerr << "Scene parser error for '" << configPath << "': " << e.what() << std::endl;
-        _exitCode = ERROR_STATUS;
+        std::cerr << "Scene parser error for '" << _configPath << "': " << e.what() << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Unexpected initialization error: " << e.what() << std::endl;
-        _exitCode = ERROR_STATUS;
     }
-    _scene.buildBVH();
 
+    _exitCode = ERROR_STATUS;
+    return false;
+}
+
+void Raytracer::startFileWatcher() {
     try {
         _fileWatcher = std::make_unique<FileWatcher>(_configPath);
         _fileWatcher->onFileChanged(
@@ -75,7 +93,8 @@ Raytracer::Raytracer(int argc, const char** argv) : _pluginLoader(_factories), _
         _watcherRunning.store(true);
         _fileWatcherThread = std::thread([this]() {
             while (_watcherRunning.load()) {
-                _fileWatcher->update();
+                if (_fileWatcher)
+                    _fileWatcher->update();
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
             }
         });
@@ -84,10 +103,15 @@ Raytracer::Raytracer(int argc, const char** argv) : _pluginLoader(_factories), _
     }
 }
 
-Raytracer::~Raytracer() {
+void Raytracer::stopFileWatcher() {
     _watcherRunning.store(false);
     if (_fileWatcherThread.joinable())
         _fileWatcherThread.join();
+}
+
+bool Raytracer::reloadScene() {
+    cleanupRenderers();
+    return loadSceneFromConfig();
 }
 
 void Raytracer::handleConfigFileChange(const std::string& path) {
@@ -103,60 +127,17 @@ void Raytracer::run() {
         while (_exitCode == SUCCESS_STATUS) {
             _reloadRequested.store(false);
 
-            if (!_renderer) {
-                std::cerr << "Error: no renderer plugin could be created from the render section"
-                          << std::endl;
-                _exitCode = ERROR_STATUS;
-                return;
-            }
+            if (!renderSceneOnce())
+                break;
 
-            const auto& camera = _scene.getCamera();
-            size_t pixelCount = static_cast<size_t>(camera.getWidth()) * camera.getHeight();
-
-            RenderContext ctx{
-                .camera = camera,
-                .pixelCount = pixelCount,
-            };
-
-            ctx.previewBuffer = FrameBuffer(pixelCount, Color(0, 0, 0));
-            ctx.finalBuffer = FrameBuffer(pixelCount, Color(0, 0, 0));
-            ctx.previewRows = std::vector<std::uint8_t>(camera.getHeight(), 0);
-            ctx.finalRows = std::vector<std::uint8_t>(camera.getHeight(), 0);
-
-            if (_graphic) {
-                _graphic->setImageSize(camera.getWidth(), camera.getHeight());
-                ctx.hasDisplay = _graphic->init();
-                if (!ctx.hasDisplay) {
-                    std::cerr << "Warning: Failed to initialize graphics display" << std::endl;
-                }
-            }
-
-            renderPreview(ctx);
             if (_reloadRequested.load()) {
-                cleanupRenderers();
+                if (!reloadScene())
+                    break;
                 continue;
             }
 
-            renderFinal(ctx);
-            if (_reloadRequested.load()) {
-                cleanupRenderers();
-                continue;
-            }
-
-            if (ctx.hasDisplay && _graphic && _graphic->isOpen()) {
-                showFinalFrame(ctx);
-                waitForDisplayClose();
-                if (_reloadRequested.load()) {
-                    cleanupRenderers();
-                    continue;
-                }
-            }
-
-            Image img(camera.getWidth(), camera.getHeight());
-            img.drawFromBuffer(ctx.finalBuffer);
             break;
         }
-
     } catch (const Scene::SceneException& e) {
         std::cerr << "Scene error while running render: " << e.what() << std::endl;
         _exitCode = ERROR_STATUS;
@@ -164,6 +145,64 @@ void Raytracer::run() {
         std::cerr << "Unexpected runtime error: " << e.what() << std::endl;
         _exitCode = ERROR_STATUS;
     }
+}
+
+bool Raytracer::renderSceneOnce() {
+    if (!_renderer) {
+        std::cerr << "Error: no renderer plugin could be created from the render section"
+                  << std::endl;
+        _exitCode = ERROR_STATUS;
+        return false;
+    }
+
+    const auto& camera = _scene.getCamera();
+    const auto width = camera.getWidth();
+    const auto height = camera.getHeight();
+    const size_t pixelCount = static_cast<size_t>(width) * static_cast<size_t>(height);
+
+    RenderContext ctx{camera,
+                      FrameBuffer(pixelCount, Color(0, 0, 0)),
+                      FrameBuffer(pixelCount, Color(0, 0, 0)),
+                      std::vector<std::uint8_t>(height, 0),
+                      std::vector<std::uint8_t>(height, 0),
+                      FrameBuffer(pixelCount, Color(0, 0, 0)),
+                      false,
+                      false,
+                      pixelCount};
+
+    if (_graphic) {
+        _graphic->setImageSize(width, height);
+        ctx.hasDisplay = _graphic->init();
+        if (!ctx.hasDisplay) {
+            std::cerr << "Warning: Failed to initialize graphics display" << std::endl;
+        }
+    }
+
+    renderPreview(ctx);
+    if (_reloadRequested.load()) {
+        cleanupRenderers();
+        return true;
+    }
+
+    renderFinal(ctx);
+    if (_reloadRequested.load()) {
+        cleanupRenderers();
+        return true;
+    }
+
+    if (ctx.hasDisplay && _graphic && _graphic->isOpen()) {
+        showFinalFrame(ctx);
+        waitForDisplayClose();
+        if (_reloadRequested.load()) {
+            cleanupRenderers();
+            return true;
+        }
+    }
+
+    Image img(width, height);
+    img.drawFromBuffer(ctx.finalBuffer);
+    cleanupRenderers();
+    return true;
 }
 
 void Raytracer::renderPreview(RenderContext& ctx) {
@@ -182,11 +221,14 @@ void Raytracer::renderPreview(RenderContext& ctx) {
                 _renderer->stop();
             break;
         }
+
         if (ctx.hasDisplay && _graphic && !_graphic->isOpen()) {
             _previewRenderer->stop();
-            _renderer->stop();
+            if (_renderer)
+                _renderer->stop();
             break;
         }
+
         updateDisplay(ctx);
         if (_previewRenderer->shouldStop())
             break;
@@ -224,6 +266,7 @@ void Raytracer::renderFinal(RenderContext& ctx) {
             }
             break;
         }
+
         _loadingBar.update(*_renderer);
 
         if (ctx.hasDisplay) {
@@ -245,6 +288,7 @@ void Raytracer::renderFinal(RenderContext& ctx) {
         renderTask.wait();
     } catch (...) {
     }
+
     _loadingBar.finish(*_renderer);
 }
 
@@ -265,6 +309,7 @@ void Raytracer::updateDisplay(RenderContext& ctx) {
              ++y) {
             if (!ctx.finalRows[y])
                 continue;
+
             const size_t rowOffset = y * static_cast<size_t>(ctx.camera.getWidth());
             for (int x = 0; x < ctx.camera.getWidth(); ++x) {
                 composed[rowOffset + static_cast<size_t>(x)] =
@@ -283,9 +328,10 @@ void Raytracer::updateDisplay(RenderContext& ctx) {
         const unsigned int b = static_cast<unsigned int>(Color::toByte(c.b));
         const unsigned int a = 255;
 
-        unsigned int packedColor = (r << 24) | (g << 16) | (b << 8) | a;
+        const unsigned int packedColor = (r << 24) | (g << 16) | (b << 8) | a;
         _graphic->updatePixel(x, y, packedColor);
     }
+
     _graphic->refresh();
 }
 
@@ -308,6 +354,7 @@ void Raytracer::waitForDisplayClose() {
         _graphic->refresh();
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
     }
+
     cleanupRenderers();
 }
 

--- a/src/core/Raytracer.hpp
+++ b/src/core/Raytracer.hpp
@@ -62,6 +62,12 @@ private:
     std::atomic<bool> _reloadRequested{false};
 
     void handleConfigFileChange(const std::string& path);
+    std::string parseConfigPath(int argc, const char** argv) const;
+    void startFileWatcher();
+    void stopFileWatcher();
+    bool loadSceneFromConfig();
+    bool reloadScene();
+    bool renderSceneOnce();
 
     struct RenderContext;
     void renderPreview(RenderContext& ctx);

--- a/src/core/Raytracer.hpp
+++ b/src/core/Raytracer.hpp
@@ -25,8 +25,6 @@ public:
     void run();
     int getStatus() const { return _exitCode; }
 
-    static Raytracer* getInstance() { return _instance; }
-
     void stop() {
         if (_renderer) {
             _renderer->stop();
@@ -40,8 +38,6 @@ public:
     }
 
 private:
-    static Raytracer* _instance;
-
     static constexpr int SUCCESS_STATUS = 0;
     static constexpr int ERROR_STATUS = 84;
 

--- a/src/core/Raytracer.hpp
+++ b/src/core/Raytracer.hpp
@@ -7,17 +7,20 @@
 #include "components/IGraphic.hpp"
 #include "components/IRenderer.hpp"
 #include "core/display/loading_bar/LoadingBar.hpp"
+#include "core/file_watcher/FileWatcher.hpp"
 #include "core/plugin_loader/PluginLoader.hpp"
 #include "core/scene/Scene.hpp"
 #include "factory/SceneFactories.hpp"
 #include "parser/SceneParser.hpp"
+#include <atomic>
+#include <thread>
 
 namespace Raytracer {
 
 class Raytracer {
 public:
     Raytracer(int argc, const char** argv);
-    ~Raytracer() = default;
+    ~Raytracer();
 
     void run();
     int getStatus() const { return _exitCode; }
@@ -53,6 +56,12 @@ private:
     Scene _scene;
     LoadingBar _loadingBar;
     std::string _configPath;
+    std::unique_ptr<FileWatcher> _fileWatcher;
+    std::thread _fileWatcherThread;
+    std::atomic<bool> _watcherRunning{false};
+    std::atomic<bool> _reloadRequested{false};
+
+    void handleConfigFileChange(const std::string& path);
 
     struct RenderContext;
     void renderPreview(RenderContext& ctx);

--- a/src/core/Raytracer.hpp
+++ b/src/core/Raytracer.hpp
@@ -57,8 +57,7 @@ private:
     LoadingBar _loadingBar;
     std::string _configPath;
     std::unique_ptr<FileWatcher> _fileWatcher;
-    std::thread _fileWatcherThread;
-    std::atomic<bool> _watcherRunning{false};
+    std::jthread _fileWatcherThread;
     std::atomic<bool> _reloadRequested{false};
 
     void handleConfigFileChange(const std::string& path);

--- a/src/core/file_watcher/FileWatcher.cpp
+++ b/src/core/file_watcher/FileWatcher.cpp
@@ -22,14 +22,12 @@ void FileWatcher::update() {
                 notifyAll();
             }
         } else {
-            // file missing: if previously existed, update state and notify
             if (_lastTime != std::filesystem::file_time_type::min()) {
                 _lastTime = std::filesystem::file_time_type::min();
                 notifyAll();
             }
         }
     } catch (...) {
-        // ignore filesystem errors during polling
     }
 }
 

--- a/src/core/file_watcher/FileWatcher.cpp
+++ b/src/core/file_watcher/FileWatcher.cpp
@@ -1,0 +1,42 @@
+#include "FileWatcher.hpp"
+
+namespace Raytracer {
+
+FileWatcher::FileWatcher(const std::string& path) : _filePath(path) {
+    try {
+        if (std::filesystem::exists(path))
+            _lastTime = std::filesystem::last_write_time(path);
+        else
+            _lastTime = std::filesystem::file_time_type::min();
+    } catch (...) {
+        _lastTime = std::filesystem::file_time_type::min();
+    }
+}
+
+void FileWatcher::update() {
+    try {
+        if (std::filesystem::exists(_filePath)) {
+            auto currentTime = std::filesystem::last_write_time(_filePath);
+            if (currentTime != _lastTime) {
+                _lastTime = currentTime;
+                notifyAll();
+            }
+        } else {
+            // file missing: if previously existed, update state and notify
+            if (_lastTime != std::filesystem::file_time_type::min()) {
+                _lastTime = std::filesystem::file_time_type::min();
+                notifyAll();
+            }
+        }
+    } catch (...) {
+        // ignore filesystem errors during polling
+    }
+}
+
+void FileWatcher::notifyAll() {
+    for (auto& cb : _callbacks) {
+        cb(_filePath);
+    }
+}
+
+} // namespace Raytracer

--- a/src/core/file_watcher/FileWatcher.hpp
+++ b/src/core/file_watcher/FileWatcher.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace Raytracer {
+
+class FileWatcher {
+public:
+    using FileCallback = std::function<void(const std::string&)>;
+
+    FileWatcher(const std::string& path);
+
+    void onFileChanged(FileCallback callback) { _callbacks.push_back(callback); }
+
+    void update();
+
+private:
+    void notifyAll();
+
+    std::string _filePath;
+    std::filesystem::file_time_type _lastTime;
+    std::vector<FileCallback> _callbacks;
+};
+
+} // namespace Raytracer

--- a/src/core/parser/SceneParser.cpp
+++ b/src/core/parser/SceneParser.cpp
@@ -14,6 +14,7 @@ void SceneParser::loadScene(const std::string& filePath, Scene& outScene) {
     libconfig::Config cfg;
 
     try {
+        outScene.clear();
         _manager.trackFile(filePath);
         cfg.readFile(filePath.c_str());
         const libconfig::Setting& root = cfg.getRoot();

--- a/src/core/scene/Scene.hpp
+++ b/src/core/scene/Scene.hpp
@@ -68,6 +68,15 @@ public:
 
     void dump();
 
+    void clear() {
+        _world.clear();
+        _lights.clear();
+        _materials.clear();
+        _sky.reset();
+        _camera.reset();
+        _graphic.reset();
+    }
+
     void buildBVH() { _world.buildBVH(); }
 
 private:


### PR DESCRIPTION
## FIXES

Issue #139 

## Description

Add a file watcher system for resetting the renderer when the file changed

### How
- Create a File Watcher class
- Use file system with last change to compare if changed
- Add clear method in scene to reset 

### Testing
1. **Execution**: ./raytracer <scene>
2. **Validation**: can change in runtime
